### PR TITLE
Review Request Notification

### DIFF
--- a/convertkit.php
+++ b/convertkit.php
@@ -29,6 +29,7 @@ define( 'CKGF_SHORT_TITLE', __( 'ConvertKit', 'convertkit' ) );
 require_once CKGF_PLUGIN_PATH . '/includes/functions.php';
 require_once CKGF_PLUGIN_PATH . '/includes/class-ckgf-api.php';
 require_once CKGF_PLUGIN_PATH . '/includes/class-ckgf-log.php';
+require_once CKGF_PLUGIN_PATH . '/includes/class-ckgf-review-request.php';
 require_once CKGF_PLUGIN_PATH . '/includes/class-wp-ckgf.php';
 
 /**

--- a/includes/class-ckgf-review-request.php
+++ b/includes/class-ckgf-review-request.php
@@ -1,0 +1,207 @@
+<?php
+/**
+ * ConvertKit Review Request class.
+ *
+ * @package CKGF
+ * @author ConvertKit
+ */
+
+/**
+ * Displays a one time review request notification in the WordPress
+ * Administration interface.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+class CKGF_Review_Request {
+
+	/**
+	 * Holds the Plugin name.
+	 *
+	 * @since   1.2.2
+	 *
+	 * @var     string
+	 */
+	private $plugin_name; // @phpstan-ignore-line
+
+	/**
+	 * Holds the Plugin slug.
+	 *
+	 * @since   1.2.2
+	 *
+	 * @var     string
+	 */
+	private $plugin_slug;
+
+	/**
+	 * Holds the number of days after the Plugin requests a review to then
+	 * display the review notification in WordPress' Administration interface.
+	 *
+	 * @since   1.2.2
+	 *
+	 * @var     int
+	 */
+	private $number_of_days_in_future = 3;
+
+	/**
+	 * Registers action and filter hooks.
+	 *
+	 * @since   1.2.2
+	 *
+	 * @param   string $plugin_name    Plugin Name (e.g. ConvertKit).
+	 * @param   string $plugin_slug    Plugin Slug (e.g. convertkit).
+	 */
+	public function __construct( $plugin_name, $plugin_slug ) {
+
+		// Store the Plugin Name and Slug in the class.
+		$this->plugin_name = $plugin_name;
+		$this->plugin_slug = $plugin_slug;
+
+		// Register an AJAX action to dismiss the review.
+		add_action( 'wp_ajax_' . str_replace( '-', '_', $this->plugin_slug ) . '_dismiss_review', array( $this, 'dismiss_review' ) );
+
+		// Maybe display a review request in the WordPress Admin notices.
+		add_action( 'admin_notices', array( $this, 'maybe_display_review_request' ) );
+
+	}
+
+	/**
+	 * Displays a dismissible WordPress Administration notice requesting a review, if requested
+	 * by the main Plugin and the Review Request hasn't been disabled.
+	 *
+	 * @since   1.2.2
+	 */
+	public function maybe_display_review_request() {
+
+		// If we're not an Admin user, bail.
+		if ( ! function_exists( 'current_user_can' ) ) {
+			return;
+		}
+		if ( ! current_user_can( 'activate_plugins' ) ) {
+			return;
+		}
+
+		// Don't display a review request on multisite.  This is so that existing Plugin
+		// users who existed prior to this feature don't get bombarded with the same
+		// notification across 100+ of their sites on a multisite network.
+		if ( is_multisite() ) {
+			return;
+		}
+
+		// If the review request was dismissed by the user, bail.
+		if ( $this->dismissed_review() ) {
+			return;
+		}
+
+		// If no review request has been set by the plugin, bail.
+		if ( ! $this->requested_review() ) {
+			return;
+		}
+
+		// If here, display the request for a review.
+		include_once CKGF_PLUGIN_PATH . '/views/backend/review/notice.php';
+
+	}
+
+	/**
+	 * Sets a flag in the options table requesting a review notification be displayed
+	 * in the WordPress Administration.
+	 *
+	 * @since   1.2.2
+	 */
+	public function request_review() {
+
+		// If a review has already been requested, bail.
+		$time = get_option( $this->plugin_slug . '-review-request' );
+		if ( ! empty( $time ) ) {
+			return;
+		}
+
+		// Request a review notification to be displayed beginning at a future timestamp.
+		update_option( $this->plugin_slug . '-review-request', time() + ( $this->number_of_days_in_future * DAY_IN_SECONDS ) );
+
+	}
+
+	/**
+	 * Flag to indicate whether a review has been requested by the Plugin,
+	 * and the minimum time has passed between the Plugin requesting a review
+	 * and now.
+	 *
+	 * @since   1.2.2
+	 *
+	 * @return  bool    Review Requested
+	 */
+	public function requested_review() {
+
+		// Bail if no review was requested by the Plugin.
+		$start_displaying_review_at = get_option( $this->plugin_slug . '-review-request' );
+		if ( empty( $start_displaying_review_at ) ) {
+			return false;
+		}
+
+		// Bail if a review was requested by the Plugin, but it's too early to display it.
+		if ( $start_displaying_review_at > time() ) {
+			return false;
+		}
+
+		// The Plugin requested a review and it's time to display the notification.
+		return true;
+
+	}
+
+	/**
+	 * Dismisses the review notification, so it isn't displayed again.
+	 *
+	 * @since   1.2.2
+	 */
+	public function dismiss_review() {
+
+		update_option( $this->plugin_slug . '-review-dismissed', 1 );
+
+		// Send success response if called via AJAX.
+		if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
+			wp_send_json_success( 1 );
+		}
+
+	}
+
+	/**
+	 * Flag to indicate whether a review request has been dismissed by the user.
+	 *
+	 * @since   1.2.2
+	 *
+	 * @return  bool    Review Dismissed
+	 */
+	public function dismissed_review() {
+
+		return get_option( $this->plugin_slug . '-review-dismissed' );
+
+	}
+
+	/**
+	 * Returns the Review URL for this Plugin.
+	 *
+	 * @since   1.2.2
+	 *
+	 * @return  string  Review URL
+	 */
+	public function get_review_url() {
+
+		return 'https://wordpress.org/support/plugin/' . $this->plugin_slug . '/reviews/?filter=5#new-post';
+
+	}
+
+	/**
+	 * Returns the Support URL for this Plugin.
+	 *
+	 * @since   1.2.2
+	 *
+	 * @return  string  Review URL
+	 */
+	public function get_support_url() {
+
+		return 'https://convertkit.com/support';
+
+	}
+
+}

--- a/includes/class-gfconvertkit.php
+++ b/includes/class-gfconvertkit.php
@@ -746,6 +746,13 @@ class GFConvertKit extends GFFeedAddOn {
 			'success'
 		);
 
+		// Request a review for the Plugin, now that the email address was successfully
+		// subscribed to ConvertKit.
+		// This can safely be called multiple times, as the review request
+		// class will ensure once a review request is dismissed by the user,
+		// it is never displayed again.
+		WP_CKGF()->get_class( 'review_request' )->request_review();
+
 	}
 
 	/**

--- a/includes/class-wp-ckgf.php
+++ b/includes/class-wp-ckgf.php
@@ -24,6 +24,16 @@ class WP_CKGF {
 	public static $instance;
 
 	/**
+	 * Holds singleton initialized classes that include
+	 * action and filter hooks.
+	 *
+	 * @since   1.2.2
+	 *
+	 * @var     array
+	 */
+	private $classes = array();
+
+	/**
 	 * Constructor. Acts as a bootstrap to load the rest of the plugin
 	 *
 	 * @since   1.2.1
@@ -32,6 +42,9 @@ class WP_CKGF {
 
 		// Register integration.
 		add_action( 'gform_loaded', array( $this, 'gravity_forms_integrations_register' ), 5 );
+
+		// Initialize.
+		add_action( 'init', array( $this, 'init' ) );
 
 		// Load language files.
 		add_action( 'init', array( $this, 'load_language_files' ) );
@@ -59,6 +72,81 @@ class WP_CKGF {
 	}
 
 	/**
+	 * Initialize admin, frontend and global Plugin classes.
+	 *
+	 * @since   1.2.2
+	 */
+	public function init() {
+
+		// Initialize class(es) to register hooks.
+		$this->initialize_admin();
+		$this->initialize_frontend();
+		$this->initialize_global();
+
+	}
+
+	/**
+	 * Initialize classes for the WordPress Administration interface
+	 *
+	 * @since   1.2.2
+	 */
+	private function initialize_admin() {
+
+		// Bail if this request isn't for the WordPress Administration interface.
+		if ( ! is_admin() ) {
+			return;
+		}
+
+		/**
+		 * Initialize integration classes for the WordPress Administration interface.
+		 *
+		 * @since   1.2.2
+		 */
+		do_action( 'convertkit_gravity_forms_initialize_admin' );
+
+	}
+
+	/**
+	 * Initialize classes for the frontend web site
+	 *
+	 * @since   1.2.2
+	 */
+	private function initialize_frontend() {
+
+		// Bail if this request isn't for the frontend web site.
+		if ( is_admin() ) {
+			return;
+		}
+
+		/**
+		 * Initialize integration classes for the frontend web site.
+		 *
+		 * @since   1.2.2
+		 */
+		do_action( 'convertkit_gravity_forms_initialize_frontend' );
+
+	}
+
+	/**
+	 * Initialize classes required globally, across the WordPress Administration, CLI, Cron and Frontend
+	 * web site.
+	 *
+	 * @since   1.2.2
+	 */
+	private function initialize_global() {
+
+		$this->classes['review_request'] = new CKGF_Review_Request( 'ConvertKit for Gravity Forms', 'convertkit-gravity-forms' );
+
+		/**
+		 * Initialize integration classes for the frontend web site.
+		 *
+		 * @since   1.2.2
+		 */
+		do_action( 'convertkit_gravity_forms_initialize_global' );
+
+	}
+
+	/**
 	 * Loads plugin textdomain
 	 *
 	 * @since   1.0.0
@@ -66,6 +154,50 @@ class WP_CKGF {
 	public function load_language_files() {
 
 		load_plugin_textdomain( 'convertkit', false, basename( dirname( CKGF_PLUGIN_BASENAME ) ) . '/languages/' );
+
+	}
+
+	/**
+	 * Returns the given class
+	 *
+	 * @since   1.2.2
+	 *
+	 * @param   string $name   Class Name.
+	 * @return  object          Class Object
+	 */
+	public function get_class( $name ) {
+
+		// If the class hasn't been loaded, throw a WordPress die screen
+		// to avoid a PHP fatal error.
+		if ( ! isset( $this->classes[ $name ] ) ) {
+			// Define the error.
+			$error = new WP_Error(
+				'convertkit_gravity_forms_get_class',
+				sprintf(
+					/* translators: %1$s: PHP class name */
+					__( 'ConvertKit for Gravity Forms Error: Could not load Plugin class <strong>%1$s</strong>', 'convertkit' ),
+					$name
+				)
+			);
+
+			// Depending on the request, return or display an error.
+			// Admin UI.
+			if ( is_admin() ) {
+				wp_die(
+					esc_attr( $error ),
+					esc_html__( 'ConvertKit for Gravity Forms Error', 'convertkit' ),
+					array(
+						'back_link' => true,
+					)
+				);
+			}
+
+			// Cron / CLI.
+			return $error;
+		}
+
+		// Return the class object.
+		return $this->classes[ $name ];
 
 	}
 

--- a/tests/_support/Helper/Acceptance.php
+++ b/tests/_support/Helper/Acceptance.php
@@ -160,6 +160,22 @@ class Acceptance extends \Codeception\Module
 	}
 
 	/**
+	 * Helper method to reset the ConvertKit Plugin settings, as if it's a clean installation.
+	 * 
+	 * @since 	1.2.2
+	 */
+	public function resetConvertKitPlugin($I)
+	{
+		// Plugin Settings.
+		$I->dontHaveOptionInDatabase('gravityformsaddon_ckgf_settings');
+		$I->dontHaveOptionInDatabase('gravityformsaddon_ckgf_version');
+
+		// Review Request.
+		$I->dontHaveOptionInDatabase('convertkit-gravity-forms-review-request');
+		$I->dontHaveOptionInDatabase('convertkit-gravity-forms-review-dismissed');
+	}
+
+	/**
 	 * Helper method to load the Gravity Forms > Settings > ConvertKit screen.
 	 * 
 	 * @since 	1.2.1

--- a/tests/acceptance/FormCest.php
+++ b/tests/acceptance/FormCest.php
@@ -77,6 +77,12 @@ class FormCest
 
 		// Check ConvertKit Notes were added to the Entry.
 		$I->checkGravityFormsSuccessNotesExist($I);
+
+		// Check that the options table does have a review request set.
+		$I->seeOptionInDatabase('convertkit-gravity-forms-review-request');
+
+		// Check that the option table does not yet have a review dismissed set.
+		$I->dontSeeOptionInDatabase('convertkit-gravity-forms-review-dismissed');
 	}
 
 	/**
@@ -144,6 +150,10 @@ class FormCest
 
 		// Check ConvertKit Notes were not added to the Entry.
 		$I->checkGravityFormsNotesDoNotExist($I);
+
+		// Check that the options table doesn't have a review request set.
+		$I->dontSeeOptionInDatabase('convertkit-gravity-forms-review-request');
+		$I->dontSeeOptionInDatabase('convertkit-gravity-forms-review-dismissed');
 	}
 
 	/**
@@ -196,6 +206,10 @@ class FormCest
 
 		// Check a ConvertKit Error Note were added to the Entry.
 		$I->checkGravityFormsErrorNotesExist($I);
+
+		// Check that the options table doesn't have a review request set.
+		$I->dontSeeOptionInDatabase('convertkit-gravity-forms-review-request');
+		$I->dontSeeOptionInDatabase('convertkit-gravity-forms-review-dismissed');
 	}
 
 	/**
@@ -251,6 +265,10 @@ class FormCest
 
 		// Check a ConvertKit Error Note were added to the Entry.
 		$I->checkGravityFormsErrorNotesExist($I);
+
+		// Check that the options table doesn't have a review request set.
+		$I->dontSeeOptionInDatabase('convertkit-gravity-forms-review-request');
+		$I->dontSeeOptionInDatabase('convertkit-gravity-forms-review-dismissed');
 	}
 
 	/**
@@ -324,6 +342,12 @@ class FormCest
 
 		// Check ConvertKit Notes were added to the Entry.
 		$I->checkGravityFormsSuccessNotesExist($I);
+
+		// Check that the options table does have a review request set.
+		$I->seeOptionInDatabase('convertkit-gravity-forms-review-request');
+
+		// Check that the option table does not yet have a review dismissed set.
+		$I->dontSeeOptionInDatabase('convertkit-gravity-forms-review-dismissed');
 	}
 
 	/**
@@ -397,6 +421,12 @@ class FormCest
 
 		// Check ConvertKit Notes were added to the Entry.
 		$I->checkGravityFormsSuccessNotesExist($I);
+
+		// Check that the options table does have a review request set.
+		$I->seeOptionInDatabase('convertkit-gravity-forms-review-request');
+
+		// Check that the option table does not yet have a review dismissed set.
+		$I->dontSeeOptionInDatabase('convertkit-gravity-forms-review-dismissed');
 	}
 
 	/**
@@ -470,6 +500,12 @@ class FormCest
 
 		// Check ConvertKit Notes were added to the Entry.
 		$I->checkGravityFormsSuccessNotesExist($I);
+
+		// Check that the options table does have a review request set.
+		$I->seeOptionInDatabase('convertkit-gravity-forms-review-request');
+
+		// Check that the option table does not yet have a review dismissed set.
+		$I->dontSeeOptionInDatabase('convertkit-gravity-forms-review-dismissed');
 	}
 
 	/**
@@ -542,6 +578,12 @@ class FormCest
 
 		// Check ConvertKit Notes were added to the Entry.
 		$I->checkGravityFormsSuccessNotesExist($I);
+
+		// Check that the options table does have a review request set.
+		$I->seeOptionInDatabase('convertkit-gravity-forms-review-request');
+
+		// Check that the option table does not yet have a review dismissed set.
+		$I->dontSeeOptionInDatabase('convertkit-gravity-forms-review-dismissed');
 	}
 
 	/**
@@ -611,6 +653,24 @@ class FormCest
 
 		// Check no ConvertKit Notes were added to the Entry.
 		$I->checkGravityFormsNotesDoNotExist($I);
+
+		// Check that the options table doesn't have a review request set.
+		$I->dontSeeOptionInDatabase('convertkit-gravity-forms-review-request');
+		$I->dontSeeOptionInDatabase('convertkit-gravity-forms-review-dismissed');
 	}
 
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 * 
+	 * @since 	1.2.2
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->deactivateConvertKitPlugin($I);
+		$I->resetConvertKitPlugin($I);
+	}
 }

--- a/tests/acceptance/ReviewRequestCest.php
+++ b/tests/acceptance/ReviewRequestCest.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Tests the ConvertKit Review Notification.
+ * 
+ * @since 	1.2.2
+ */
+class ReviewRequestCest
+{
+	/**
+	 * Run common actions before running the test functions in this class.
+	 * 
+	 * @since 	1.2.2
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function _before(AcceptanceTester $I)
+	{
+		$I->activateConvertKitPlugin($I);
+	}
+
+	/**
+	 * Test that the review request is displayed when the options table entries
+	 * have the required values to display the review request notification.
+	 * 
+	 * @since 	1.2.2
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testReviewRequestNotificationDisplayed(AcceptanceTester $I)
+	{
+		// Set review request option with a timestamp in the past, to emulate
+		// the Plugin having set this a few days ago.
+		$I->haveOptionInDatabase('convertkit-gravity-forms-review-request', time() - 3600 );
+
+		// Navigate to a screen in the WordPress Administration.
+		$I->amOnAdminPage('index.php');
+
+		// Confirm the review displays.
+		$I->seeElementInDOM('div.review-convertkit-gravity-forms');
+
+		// Confirm links are correct.
+		$I->seeInSource('<a href="https://wordpress.org/support/plugin/convertkit-gravity-forms/reviews/?filter=5#new-post" class="button button-primary" rel="noopener" target="_blank">');
+		$I->seeInSource('<a href="https://convertkit.com/support" class="button" rel="noopener" target="_blank">');
+	}
+
+	/**
+	 * Test that the review request is dismissed and does not reappear
+	 * on a subsequent page load.
+	 * 
+	 * @since 	1.2.2
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testReviewRequestNotificationDismissed(AcceptanceTester $I)
+	{
+		// Set review request option with a timestamp in the past, to emulate
+		// the Plugin having set this a few days ago.
+		$I->haveOptionInDatabase('convertkit-gravity-forms-review-request', time() - 3600 );
+
+		// Navigate to a screen in the WordPress Administration.
+		$I->amOnAdminPage('index.php');
+
+		// Confirm the review displays.
+		$I->seeElementInDOM('div.review-convertkit-gravity-forms');
+
+		// Dismiss the review request.
+		$I->click('div.review-convertkit-gravity-forms button.notice-dismiss');
+
+		// Navigate to a screen in the WordPress Administration.
+		$I->amOnAdminPage('index.php');
+
+		// Confirm the review notification no longer displays.
+		$I->dontSeeElementInDOM('div.review-convertkit-gravity-forms');
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 * 
+	 * @since 	1.2.2
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->deactivateConvertKitPlugin($I);
+		$I->resetConvertKitPlugin($I);
+	}
+}

--- a/views/backend/review/notice.php
+++ b/views/backend/review/notice.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Notification output for a review request.
+ *
+ * @package CKGF
+ * @author ConvertKit
+ */
+
+?>
+
+<div class="notice notice-info is-dismissible review-<?php echo esc_attr( $this->plugin_slug ); ?>">
+	<p>
+		<?php
+		echo esc_html(
+			sprintf(
+				/* translators: Plugin Name */
+				__( 'We\'d be super grateful if you could spread the word about %s and give it a 5 star rating on WordPress?', 'convertkit' ),
+				$this->plugin_name
+			)
+		);
+		?>
+	</p>
+	<p>
+		<a href="<?php echo esc_attr( $this->get_review_url() ); ?>" class="button button-primary" rel="noopener" target="_blank">
+			<?php esc_html_e( 'Yes, leave review', 'convertkit' ); ?>
+		</a>
+		<a href="<?php echo esc_attr( $this->get_support_url() ); ?>" class="button" rel="noopener" target="_blank">
+			<?php
+			echo esc_html(
+				sprintf(
+					/* translators: Plugin Name */
+					__( 'No, I\'m having issues with %s', 'convertkit' ),
+					$this->plugin_name
+				)
+			);
+			?>
+		</a>
+	</p>
+
+	<script type="text/javascript">
+		jQuery( document ).ready( function( $ ) {
+			// Dismiss Review Notification.
+			$( 'div.review-<?php echo esc_attr( $this->plugin_slug ); ?>' ).on( 'click', 'a, button.notice-dismiss', function( e ) {
+
+				// Do request
+				$.post( 
+					ajaxurl, 
+					{
+						action: '<?php echo esc_attr( str_replace( '-', '_', $this->plugin_slug ) ); ?>_dismiss_review',
+					},
+					function( response ) {
+					}
+				);
+
+				// Hide notice
+				$( 'div.review-<?php echo esc_attr( $this->plugin_slug ); ?>' ).hide();
+
+			} );
+		} );
+	</script>
+</div>
+

--- a/views/backend/review/notice.php
+++ b/views/backend/review/notice.php
@@ -14,7 +14,7 @@
 		echo esc_html(
 			sprintf(
 				/* translators: Plugin Name */
-				__( 'We\'d be super grateful if you could spread the word about %s and give it a 5 star rating on WordPress?', 'convertkit' ),
+				__( 'We\'d be super grateful if you could spread the word about %s and give it a 5 star rating on WordPress.', 'convertkit' ),
 				$this->plugin_name
 			)
 		);


### PR DESCRIPTION
## Summary

Similar to the [main ConvertKit Plugin](https://github.com/ConvertKit/convertkit-wordpress/pull/279/), adds a notification in the WordPress Administration interface requesting the user leave a 5 star review on [wordpress.org](https://wordpress.org/support/plugin/convertkit-gravity-forms/reviews/), to assist with the Plugin's ranking on search results within WordPress.

![Screenshot 2022-03-22 at 14 51 52](https://user-images.githubusercontent.com/1462305/159510454-0b3d015e-8639-46fc-bdb1-64494b1d1a03.png)

Clicking either button or the close button hides the notification for life; no other WordPress Administrator will see it.

Clicking `Yes, Leave Review` hides the notification, and opens a new browser tab at https://wordpress.org/support/plugin/convertkit-gravity-forms/reviews/?filter=5#new-post
Clicking `No, I'm having issues with ConvertKit` opens a new browser tab at https://convertkit.com/support

This notification will only display when the following conditions are all met:
- The user is in the WordPress Administration interface,
- The user is an Administrator (lower roles, such as Editor or Author will not see this notification),
- The Plugin is fully configured (both settings and feed settings defined),
- The form is submitted successfully, with the email address successfully subscribed to ConvertKit,
- It has been at least 3 days since an action was performed (this is to avoid bombarding the user with notifications so soon after using the Plugin)
- The notification has not previously been dismissed.
- The site is not a Multisite installation (Multisite allows multiple sites within a single WordPress instance; showing notifications on every site would therefore be frustrating for the site owner who most likely controls all sites in the single WordPress instance).

The conditions are deliberately restrictive, to avoid aggressively and persistently asking the user for a review, and to prevent us adding to the potential large number of notifications that various Themes and Plugins add to WordPress' Administration interface: https://wptavern.com/new-dobby-plugin-captures-and-hides-unwanted-wordpress-admin-notices

## Testing

- FormCest: Tests to ensure the notification displays, or does not display, depending on the actions performed.
- ReviewRequestCest: Tests that the notification never displays once dismissed.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)