### PR TITLE
Improve Test Performance

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,9 +43,8 @@ jobs:
     # For PHP, make sure that an nginx configuration file exists for the required PHP version in this repository at tests/nginx/php-x.x.conf
     strategy:
       matrix:
-        wp-versions: [ '5.9' ] #[ '5.6.7', '5.7.5', '5.8.3', '5.9' ]
+        wp-versions: [ '5.9.2' ] #[ '5.6.7', '5.7.5', '5.8.3', '5.9' ]
         php-versions: [ '7.2', '7.3', '7.4', '8.0' ] #[ '7.3', '7.4', '8.0', '8.1' ]
-      max-parallel: 1 # Run one at a time, otherwise reading API data after tests results in false positives due to concurrency
 
     # Steps to install, configure and run tests
     steps:
@@ -75,9 +74,6 @@ jobs:
         with:
           path: ${{ env.PLUGIN_DIR }}
 
-      - name: Check PHP Version
-        run: php -v
-
       # This step is deliberate, to force PHP 7.4 for WP-CLI to work.
       # PHP 8.x results in the workflow failing due to incompatibilities between WP-CLI and PHP 8.x.
       - name: Install PHP 7.4.26
@@ -85,9 +81,6 @@ jobs:
         with:
           php-version: 7.4.26
           coverage: xdebug
-
-      - name: Check PHP Version after 7.4.26
-        run: php -v
 
       # We install WP-CLI, as it provides useful commands to setup and install WordPress through the command line.
       - name: Install WP-CLI
@@ -132,9 +125,6 @@ jobs:
         with:
           php-version: ${{ matrix.php-versions }}
           coverage: xdebug
-
-      - name: Check PHP Version after installing matrix version
-        run: php -v
 
       # Make sure that an nginx configuration file exists in this repository at tests/nginx/php-x.x.conf.
       # Refer to an existing .conf file in this repository if you need to create a new one e.g. for a new PHP version.
@@ -204,7 +194,7 @@ jobs:
       # Run Codeception Acceptance Tests.
       - name: Run Acceptance Tests
         working-directory: ${{ env.PLUGIN_DIR }}
-        run: php vendor/bin/codecept run acceptance
+        run: php vendor/bin/codecept run acceptance --fail-fast
 
       # If the repository has other tests, such as unit tests, add the Codeception commands here to run them now.
 

--- a/tests/_support/Helper/Acceptance.php
+++ b/tests/_support/Helper/Acceptance.php
@@ -76,38 +76,36 @@ class Acceptance extends \Codeception\Module
 	}
 
 	/**
-	 * Helper method to activate the Plugin.
+	 * Helper method to activate the ConvertKit Plugin, checking
+	 * it activated and no errors were output.
 	 * 
 	 * @since 	1.2.1
-	 * 
-	 * @param 	AcceptanceTester 	$I AcceptanceTester.
 	 */
 	public function activateConvertKitPlugin($I)
 	{
-		// Login as the Administrator
-		$I->loginAsAdmin();
-
-		// Go to the Plugins screen in the WordPress Administration interface.
-		$I->amOnPluginsPage();
-
-		// Activate the Plugin.
-		$I->activatePlugin('convertkit-gravity-forms');
-
-		// Check that the Plugin activated successfully.
-		$I->seePluginActivated('convertkit-gravity-forms');
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+		$I->activateThirdPartyPlugin($I, 'convertkit-gravity-forms');
 	}
 
 	/**
-	 * Helper method to activate the Gravity Forms Plugin and the ConvertKit for Gravity Forms Plugin.
+	 * Helper method to deactivate the ConvertKit Plugin, checking
+	 * it activated and no errors were output.
 	 * 
 	 * @since 	1.2.1
-	 * 
-	 * @param 	AcceptanceTester 	$I AcceptanceTester.
 	 */
-	public function activateGravityFormsAndConvertKitPlugins($I)
+	public function deactivateConvertKitPlugin($I)
+	{
+		$I->deactivateThirdPartyPlugin($I, 'convertkit-gravity-forms');
+	}
+
+	/**
+	 * Helper method to activate a third party Plugin, checking
+	 * it activated and no errors were output.
+	 * 
+	 * @since 	1.2.2
+	 * 
+	 * @param 	string 	$name 	Plugin Slug.
+	 */
+	public function activateThirdPartyPlugin($I, $name)
 	{
 		// Login as the Administrator
 		$I->loginAsAdmin();
@@ -115,33 +113,33 @@ class Acceptance extends \Codeception\Module
 		// Go to the Plugins screen in the WordPress Administration interface.
 		$I->amOnPluginsPage();
 
-		// Activate the Gravity Forms Plugin.
-		$I->activatePlugin('gravity-forms');
-
-		// Check that the Plugin activated successfully.
-		$I->seePluginActivated('gravityforms');
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-
 		// Activate the Plugin.
-		$I->activatePlugin('convertkit-gravity-forms');
+		$I->activatePlugin($name);
 
-		// Check that the Plugin activated successfully.
-		$I->seePluginActivated('convertkit-gravity-forms');
+		// Some Plugins have a different slug when activated.
+		switch($name) {
+			case 'gravity-forms':
+				$I->seePluginActivated('gravityforms');
+				break;
 
+			default:
+				$I->seePluginActivated($name);
+				break;
+		}
+		
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 	}
 
 	/**
-	 * Helper method to deactivate the Plugin.
+	 * Helper method to activate a third party Plugin, checking
+	 * it activated and no errors were output.
 	 * 
-	 * @since 	1.2.1
+	 * @since 	1.2.2
 	 * 
-	 * @param 	AcceptanceTester 	$I AcceptanceTester.
+	 * @param 	string 	$name 	Plugin Slug.
 	 */
-	public function deactivateConvertKitPlugin($I)
+	public function deactivateThirdPartyPlugin($I, $name)
 	{
 		// Login as the Administrator
 		$I->loginAsAdmin();
@@ -150,13 +148,29 @@ class Acceptance extends \Codeception\Module
 		$I->amOnPluginsPage();
 
 		// Deactivate the Plugin.
-		$I->deactivatePlugin('convertkit-gravity-forms');
+		$I->deactivatePlugin($name);
 
 		// Check that the Plugin deactivated successfully.
-		$I->seePluginDeactivated('convertkit-gravity-forms');
+		$I->seePluginDeactivated($name);
 
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
+	}
+
+	/**
+	 * Helper method to reset the ConvertKit Plugin settings, as if it's a clean installation.
+	 * 
+	 * @since 	1.2.2
+	 */
+	public function resetConvertKitPlugin($I)
+	{
+		// Plugin Settings.
+		$I->dontHaveOptionInDatabase('gravityformsaddon_ckgf_settings');
+		$I->dontHaveOptionInDatabase('gravityformsaddon_ckgf_version');
+
+		// Review Request.
+		$I->dontHaveOptionInDatabase('convertkit-gravity-forms-review-request');
+		$I->dontHaveOptionInDatabase('convertkit-gravity-forms-review-dismissed');
 	}
 
 	/**
@@ -450,6 +464,20 @@ class Acceptance extends \Codeception\Module
 		$I->amOnAdminPage('admin.php?page=gf_entries');
 		$I->click('table.gf_entries tbody tr.entry_row:first-child a[aria-label="View this entry"]');
 		$I->dontSeeElementInDOM('#notes div[data-type="ckgf"]');
+	}
+
+	/**
+	 * Generates a unique email address for use in a test, comprising of a prefix,
+	 * date + time and PHP version number.
+	 * 
+	 * This ensures that if tests are run in parallel, the same email address
+	 * isn't used for two tests across parallel testing runs.
+	 * 
+	 * @since 	1.2.2
+	 */
+	public function generateEmailAddress()
+	{
+		return 'wordpress-gravity-forms-' . date( 'Y-m-d-H-i-s' ) . '-php-' . PHP_VERSION_ID . '@n7studios.com';
 	}
 
 	/**

--- a/tests/_support/Helper/Acceptance.php
+++ b/tests/_support/Helper/Acceptance.php
@@ -147,11 +147,18 @@ class Acceptance extends \Codeception\Module
 		// Go to the Plugins screen in the WordPress Administration interface.
 		$I->amOnPluginsPage();
 
-		// Deactivate the Plugin.
-		$I->deactivatePlugin($name);
+		// Some Plugins have a different slug when activated/deactivated.
+		switch($name) {
+			case 'gravity-forms':
+				$I->deactivatePlugin('gravityforms');
+				$I->seePluginDeactivated('gravity-forms');
+				break;
 
-		// Check that the Plugin deactivated successfully.
-		$I->seePluginDeactivated($name);
+			default:
+				$I->deactivatePlugin($name);
+				$I->seePluginDeactivated($name);
+				break;
+		}
 
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);

--- a/tests/_support/Helper/Acceptance.php
+++ b/tests/_support/Helper/Acceptance.php
@@ -230,7 +230,7 @@ class Acceptance extends \Codeception\Module
 		$I->amOnAdminPage('admin.php?page=gf_new_form');
 
 		// Define Title.
-		$I->fillField('#new_form_title', 'ConvertKit Form Test');
+		$I->fillField('#new_form_title', 'ConvertKit Form Test: '.date('Y-m-d H:i:s').' on PHP '.PHP_VERSION_ID);
 
 		// Click Create Form button.
 		$I->click('Create Form');
@@ -531,7 +531,7 @@ class Acceptance extends \Codeception\Module
 	{
 		// Get Subscribers.
 		$subscribers = $this->apiGetSubscribersByTagID($tagID);
-			
+
 		$subscriberTagged = false;
 		foreach ($subscribers as $subscriber) {
 			if ($subscriber['subscriber']['email_address'] == $emailAddress) {

--- a/tests/acceptance.suite.yml
+++ b/tests/acceptance.suite.yml
@@ -21,7 +21,7 @@ modules:
             #import the dump before the tests; this means the test site database will be repopulated before the tests.
             populate: true
             # re-import the dump between tests; this means the test site database will be repopulated between the tests.
-            cleanup: true
+            cleanup: false
             waitlock: 10
             url: '%TEST_SITE_WP_URL%'
             urlReplacement: true #replace the hardcoded dump URL with the one above

--- a/tests/acceptance.suite.yml
+++ b/tests/acceptance.suite.yml
@@ -21,7 +21,7 @@ modules:
             #import the dump before the tests; this means the test site database will be repopulated before the tests.
             populate: true
             # re-import the dump between tests; this means the test site database will be repopulated between the tests.
-            cleanup: false
+            cleanup: true
             waitlock: 10
             url: '%TEST_SITE_WP_URL%'
             urlReplacement: true #replace the hardcoded dump URL with the one above

--- a/tests/acceptance/ActivateDeactivatePluginCest.php
+++ b/tests/acceptance/ActivateDeactivatePluginCest.php
@@ -3,17 +3,6 @@
 class ActivateDeactivatePluginCest
 {
 	/**
-	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.2.1
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function _before(AcceptanceTester $I)
-	{
-	}
-
-	/**
 	 * Activate the Plugin and confirm a success notification
 	 * is displayed with no errors.
 	 * 
@@ -23,7 +12,8 @@ class ActivateDeactivatePluginCest
 	 */
 	public function testPluginActivation(AcceptanceTester $I)
 	{
-		$I->activateGravityFormsAndConvertKitPlugins($I);
+		$I->activateConvertKitPlugin($I);
+		$I->activateThirdPartyPlugin($I, 'gravity-forms');
 	}
 
 	/**
@@ -50,5 +40,20 @@ class ActivateDeactivatePluginCest
 	public function testPluginDeactivation(AcceptanceTester $I)
 	{
 		$I->deactivateConvertKitPlugin($I);
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 * 
+	 * @since 	1.2.2
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->deactivateConvertKitPlugin($I);
+		$I->resetConvertKitPlugin($I);
 	}
 }

--- a/tests/acceptance/ActivateDeactivatePluginCest.php
+++ b/tests/acceptance/ActivateDeactivatePluginCest.php
@@ -3,57 +3,33 @@
 class ActivateDeactivatePluginCest
 {
 	/**
-	 * Activate the Plugin and confirm a success notification
-	 * is displayed with no errors.
+	 * Test that activating the Plugin and the Gravity Forms Plugins works
+	 * with no errors.
 	 * 
 	 * @since 	1.2.1
 	 * 
 	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testPluginActivation(AcceptanceTester $I)
+	public function testPluginActivationDeactivation(AcceptanceTester $I)
 	{
 		$I->activateConvertKitPlugin($I);
 		$I->activateThirdPartyPlugin($I, 'gravity-forms');
+		$I->deactivateConvertKitPlugin($I);
+		$I->deactivateThirdPartyPlugin($I, 'gravity-forms');
 	}
 
 	/**
-	 * Activate the Plugin without the Gravity Forms Plugin and confirm a success notification
-	 * is displayed with no errors.
+	 * Test that activating the Plugin, without activating the Gravity Forms Plugin, works
+	 * with no errors.
 	 * 
 	 * @since 	1.2.1
 	 * 
 	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testPluginActivationWithoutGravityForms(AcceptanceTester $I)
+	public function testPluginActivationDeactivationWithoutGravityForms(AcceptanceTester $I)
 	{
 		$I->activateConvertKitPlugin($I);
-	}
-
-	/**
-	 * Deactivate the Plugin and confirm a success notification
-	 * is displayed with no errors.
-	 * 
-	 * @since 	1.2.1
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testPluginDeactivation(AcceptanceTester $I)
-	{
 		$I->deactivateConvertKitPlugin($I);
-	}
 
-	/**
-	 * Deactivate and reset Plugin(s) after each test, if the test passes.
-	 * We don't use _after, as this would provide a screenshot of the Plugin
-	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.2.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function _passed(AcceptanceTester $I)
-	{
-		$I->deactivateConvertKitPlugin($I);
-		$I->resetConvertKitPlugin($I);
 	}
 }

--- a/tests/acceptance/AnyErrorsOnBlankInstallCest.php
+++ b/tests/acceptance/AnyErrorsOnBlankInstallCest.php
@@ -3,17 +3,6 @@
 class AnyErrorsOnBlankInstallCest
 {
 	/**
-	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.2.1
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function _before(AcceptanceTester $I)
-	{
-	}
-
-	/**
 	 * Check that no PHP errors or notices are displayed at Gravity Forms > Settings > ConvertKit, when the Plugin is activated
 	 * and not configured.
 	 * 
@@ -23,10 +12,26 @@ class AnyErrorsOnBlankInstallCest
 	 */
 	public function testSettingsScreen(AcceptanceTester $I)
 	{
-		// Activate Plugin.
-		$I->activateGravityFormsAndConvertKitPlugins($I);
+		// Activate Plugins.
+		$I->activateConvertKitPlugin($I);
+		$I->activateThirdPartyPlugin($I, 'gravity-forms');
 
 		// Go to the Plugin's Settings > General Screen.
 		$I->loadConvertKitSettingsScreen($I);
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 * 
+	 * @since 	1.2.2
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->deactivateConvertKitPlugin($I);
+		$I->resetConvertKitPlugin($I);
 	}
 }

--- a/tests/acceptance/AnyErrorsOnBlankInstallCest.php
+++ b/tests/acceptance/AnyErrorsOnBlankInstallCest.php
@@ -18,20 +18,10 @@ class AnyErrorsOnBlankInstallCest
 
 		// Go to the Plugin's Settings > General Screen.
 		$I->loadConvertKitSettingsScreen($I);
-	}
 
-	/**
-	 * Deactivate and reset Plugin(s) after each test, if the test passes.
-	 * We don't use _after, as this would provide a screenshot of the Plugin
-	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.2.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function _passed(AcceptanceTester $I)
-	{
+		// Deactivate Plugins.
 		$I->deactivateConvertKitPlugin($I);
+		$I->deactivateThirdPartyPlugin($I, 'gravity-forms');
 		$I->resetConvertKitPlugin($I);
 	}
 }

--- a/tests/acceptance/FormCest.php
+++ b/tests/acceptance/FormCest.php
@@ -626,6 +626,7 @@ class FormCest
 	public function _passed(AcceptanceTester $I)
 	{
 		$I->deactivateConvertKitPlugin($I);
+		$I->deactivateThirdPartyPlugin($I, 'gravity-forms');
 		$I->resetConvertKitPlugin($I);
 	}
 }

--- a/tests/acceptance/FormCest.php
+++ b/tests/acceptance/FormCest.php
@@ -16,7 +16,8 @@ class FormCest
 	 */
 	public function _before(AcceptanceTester $I)
 	{
-		$I->activateGravityFormsAndConvertKitPlugins($I);
+		$I->activateConvertKitPlugin($I);
+		$I->activateThirdPartyPlugin($I, 'gravity-forms');
 		$I->setupConvertKitPlugin($I);
 	}
 
@@ -44,7 +45,7 @@ class FormCest
 		// Define Name, Email Address and Custom Field Data for this Test.
 		$firstName = 'First';
 		$lastName = 'Last';
-		$emailAddress = 'wordpress-gravityforms-' . date('YmdHis') . '@n7studios.com';
+		$emailAddress = $I->generateEmailAddress();
 		$customFields = [
 			'last_name' => $lastName,
 		];
@@ -114,7 +115,7 @@ class FormCest
 		// Define Name, Email Address and Custom Field Data for this Test.
 		$firstName = 'First';
 		$lastName = 'Last';
-		$emailAddress = 'wordpress-gravityforms-' . date('YmdHis') . '@n7studios.com';
+		$emailAddress = $I->generateEmailAddress();
 
 		// Logout as the WordPress Administrator.
 		$I->logOut();
@@ -284,7 +285,7 @@ class FormCest
 		// Define Name, Email Address and Custom Field Data for this Test.
 		$firstName = 'First';
 		$lastName = 'Last';
-		$emailAddress = 'wordpress-gravityforms-' . date('YmdHis') . '@n7studios.com';
+		$emailAddress = $I->generateEmailAddress();
 		$customFields = [
 			'last_name' => $lastName,
 		];
@@ -357,7 +358,7 @@ class FormCest
 		// Define Name, Email Address and Custom Field Data for this Test.
 		$firstName = 'First';
 		$lastName = 'Last';
-		$emailAddress = 'wordpress-gravityforms-' . date('YmdHis') . '@n7studios.com';
+		$emailAddress = $I->generateEmailAddress();
 		$customFields = [
 			'last_name' => $lastName,
 		];
@@ -430,7 +431,7 @@ class FormCest
 		// Define Name, Email Address and Custom Field Data for this Test.
 		$firstName = 'First';
 		$lastName = 'Last';
-		$emailAddress = 'wordpress-gravityforms-' . date('YmdHis') . '@n7studios.com';
+		$emailAddress = $I->generateEmailAddress();
 		$customFields = [
 			'last_name' => $lastName,
 		];
@@ -503,7 +504,7 @@ class FormCest
 		// Define Name, Email Address and Custom Field Data for this Test.
 		$firstName = 'First';
 		$lastName = 'Last';
-		$emailAddress = 'wordpress-gravityforms-' . date('YmdHis') . '@n7studios.com';
+		$emailAddress = $I->generateEmailAddress();
 		$customFields = [
 			'last_name' => $lastName,
 		];
@@ -577,7 +578,7 @@ class FormCest
 		// Define Name, Email Address and Custom Field Data for this Test.
 		$firstName = 'First';
 		$lastName = 'Last';
-		$emailAddress = 'wordpress-gravityforms-' . date('YmdHis') . '@n7studios.com';
+		$emailAddress = $I->generateEmailAddress();
 
 		// Logout as the WordPress Administrator.
 		$I->logOut();
@@ -613,4 +614,18 @@ class FormCest
 		$I->checkGravityFormsNotesDoNotExist($I);
 	}
 
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 * 
+	 * @since 	1.2.2
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->deactivateConvertKitPlugin($I);
+		$I->resetConvertKitPlugin($I);
+	}
 }

--- a/tests/acceptance/SettingCest.php
+++ b/tests/acceptance/SettingCest.php
@@ -15,7 +15,8 @@ class SettingCest
 	 */
 	public function _before(AcceptanceTester $I)
 	{
-		$I->activateGravityFormsAndConvertKitPlugins($I);
+		$I->activateConvertKitPlugin($I);
+		$I->activateThirdPartyPlugin($I, 'gravity-forms');
 	}
 
 	/**
@@ -125,5 +126,20 @@ class SettingCest
 
 		// Check the field remains unticked.
 		$I->dontSeeCheckboxIsChecked('#debug');
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 * 
+	 * @since 	1.2.2
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->deactivateConvertKitPlugin($I);
+		$I->resetConvertKitPlugin($I);
 	}
 }

--- a/tests/acceptance/SettingCest.php
+++ b/tests/acceptance/SettingCest.php
@@ -140,6 +140,7 @@ class SettingCest
 	public function _passed(AcceptanceTester $I)
 	{
 		$I->deactivateConvertKitPlugin($I);
+		$I->deactivateThirdPartyPlugin($I, 'gravity-forms');
 		$I->resetConvertKitPlugin($I);
 	}
 }


### PR DESCRIPTION
## Summary

Improves test performance in GitHub Actions by running tests in parallel instead of sequentially.

Changes to tests are made to ensure that they can run in parallel by:
- Generating unique email addresses for tests, using the current date, time and PHP version
- Ensuring that the test environment is reset by the test (by way of `_before()` and `_passed()`), rather than reloading the entire database between tests

Test run time across all environments totals ~ 8 minutes, where it was previously ~ 27 minutes.

![Screenshot 2022-03-22 at 16 08 29](https://user-images.githubusercontent.com/1462305/159526826-c54d1965-42d3-4ff7-a779-2d74b4b51299.png)

![Screenshot 2022-03-22 at 18 26 07](https://user-images.githubusercontent.com/1462305/159550244-708b99e0-fd23-4ad0-a649-d820e86ff51e.png)

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)