### PR TITLE
Add PHPStan for Static Analysis

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -196,6 +196,11 @@ jobs:
         working-directory: ${{ env.PLUGIN_DIR }}
         run: php vendor/bin/phpcs ./ -v
 
+      # Run PHPStan for static analysis.
+      - name: Run PHPStan Static Analysis
+        working-directory: ${{ env.PLUGIN_DIR }}
+        run: php vendor/bin/phpstan --memory-limit=512M
+
       # Build Codeception Tests.
       - name: Build Tests
         working-directory: ${{ env.PLUGIN_DIR }}

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,9 @@
         "codeception/util-universalframework": "^1.0",
         "squizlabs/php_codesniffer": "3.*",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
-        "wp-coding-standards/wpcs": "*"
+        "wp-coding-standards/wpcs": "*",
+        "phpstan/phpstan": "^1.4",
+        "szepeviktor/phpstan-wordpress": "^1.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/includes/class-ckgf-api.php
+++ b/includes/class-ckgf-api.php
@@ -17,23 +17,23 @@ class CKGF_API {
 	/**
 	 * ConvertKit API Key
 	 *
-	 * @var string
+	 * @var mixed   bool | string
 	 */
-	protected $api_key;
+	protected $api_key = false;
 
 	/**
 	 * ConvertKit API Secret
 	 *
-	 * @var string
+	 * @var mixed   bool | string
 	 */
-	protected $api_secret;
+	protected $api_secret = false;
 
 	/**
 	 * Save debug data to log
 	 *
-	 * @var  string
+	 * @var  bool
 	 */
-	protected $debug;
+	protected $debug = false;
 
 	/**
 	 * Version of ConvertKit API
@@ -59,11 +59,11 @@ class CKGF_API {
 	/**
 	 * Sets up the API with the required credentials.
 	 *
-	 * @since   1.2.1
+	 * @since   1.9.6
 	 *
-	 * @param   string $api_key        ConvertKit API Key.
-	 * @param   string $api_secret     ConvertKit API Secret.
-	 * @param   string $debug          Save data to log.
+	 * @param   bool|string $api_key        ConvertKit API Key.
+	 * @param   bool|string $api_secret     ConvertKit API Secret.
+	 * @param   bool  		$debug          Save data to log.
 	 */
 	public function __construct( $api_key = false, $api_secret = false, $debug = false ) {
 
@@ -155,7 +155,7 @@ class CKGF_API {
 	public function form_subscribe( $form_id, $email, $first_name, $fields = false, $tag_ids = false ) {
 
 		// Backward compat. if $email is an array comprising of email and name keys.
-		if ( is_array( $email ) ) {
+		if ( is_array( $email ) ) { // @phpstan-ignore-line.
 			_deprecated_function( __FUNCTION__, '1.9.6', 'form_subscribe( $form_id, $email, $first_name )' );
 			$first_name = $email['name'];
 			$email      = $email['email'];
@@ -254,11 +254,11 @@ class CKGF_API {
 
 		// If no sequences exist, return WP_Error.
 		if ( ! isset( $response['courses'] ) ) {
-			$this->log( 'API: get_sequences(): Error: No sequences exist in ConvertKit.', 'convertkit' );
+			$this->log( 'API: get_sequences(): Error: No sequences exist in ConvertKit.' );
 			return new WP_Error( 'convertkit_api_error', __( 'No sequences exist in ConvertKit. Visit your ConvertKit account and create your first sequence.', 'convertkit' ) );
 		}
 		if ( ! count( $response['courses'] ) ) {
-			$this->log( 'API: get_sequences(): Error: No sequences exist in ConvertKit.', 'convertkit' );
+			$this->log( 'API: get_sequences(): Error: No sequences exist in ConvertKit.' );
 			return new WP_Error( 'convertkit_api_error', __( 'No sequences exist in ConvertKit. Visit your ConvertKit account and create your first sequence.', 'convertkit' ) );
 		}
 
@@ -346,11 +346,11 @@ class CKGF_API {
 
 		// If no tags exist, return WP_Error.
 		if ( ! isset( $response['tags'] ) ) {
-			$this->log( 'API: get_tags(): Error: No tags exist in ConvertKit.', 'convertkit' );
+			$this->log( 'API: get_tags(): Error: No tags exist in ConvertKit.' );
 			return new WP_Error( 'convertkit_api_error', __( 'No tags exist in ConvertKit. Visit your ConvertKit account and create your first tag.', 'convertkit' ) );
 		}
 		if ( ! count( $response['tags'] ) ) {
-			$this->log( 'API: get_tags(): Error: No tags exist in ConvertKit.', 'convertkit' );
+			$this->log( 'API: get_tags(): Error: No tags exist in ConvertKit.' );
 			return new WP_Error( 'convertkit_api_error', __( 'No tags exist in ConvertKit. Visit your ConvertKit account and create your first tag.', 'convertkit' ) );
 		}
 
@@ -367,10 +367,10 @@ class CKGF_API {
 	 *
 	 * @since   1.2.1
 	 *
-	 * @param   string $tag_id     Tag ID.
+	 * @param   int    $tag_id     Tag ID.
 	 * @param   string $email      Email Address.
 	 * @param   mixed  $fields     Custom Fields (false|array).
-	 * @return  mixed               WP_Error | array
+	 * @return  WP_Error|array
 	 */
 	public function tag_subscribe( $tag_id, $email, $fields = false ) {
 
@@ -399,7 +399,7 @@ class CKGF_API {
 		 * @since   1.9.6
 		 *
 		 * @param   array   $response   API Response
-		 * @param   string  $tag_id     Tag ID
+		 * @param   int  	$tag_id     Tag ID
 		 * @param   string  $email      Email Address
 		 * @param   mixed   $fields     Custom Fields (false|array).
 		 */
@@ -638,11 +638,11 @@ class CKGF_API {
 
 		// If no custom fields exist, return WP_Error.
 		if ( ! isset( $response['custom_fields'] ) ) {
-			$this->log( 'API: get_custom_fields(): Error: No custom fields exist in ConvertKit.', 'convertkit' );
+			$this->log( 'API: get_custom_fields(): Error: No custom fields exist in ConvertKit.' );
 			return new WP_Error( 'convertkit_api_error', __( 'No custom fields exist in ConvertKit. Visit your ConvertKit account and create your first custom field.', 'convertkit' ) );
 		}
 		if ( ! count( $response['custom_fields'] ) ) {
-			$this->log( 'API: get_custom_fields(): Error: No custom fields exist in ConvertKit.', 'convertkit' );
+			$this->log( 'API: get_custom_fields(): Error: No custom fields exist in ConvertKit.' );
 			return new WP_Error( 'convertkit_api_error', __( 'No custom fields exist in ConvertKit. Visit your ConvertKit account and create your first custom field.', 'convertkit' ) );
 		}
 
@@ -696,7 +696,7 @@ class CKGF_API {
 		// Inject JS for subscriber forms to work.
 		$scripts = new WP_Scripts();
 		$script  = "<script type='text/javascript' src='" . trailingslashit( $scripts->base_url ) . "wp-includes/js/jquery/jquery.js?ver=1.4.0'></script>"; // phpcs:ignore
-		$script .= "<script type='text/javascript' src='" . CONVERTKIT_PLUGIN_URL . 'resources/frontend/js/convertkit.js?ver=' . CONVERTKIT_PLUGIN_VERSION . "'></script>"; // phpcs:ignore
+		$script .= "<script type='text/javascript' src='" . CKGF_PLUGIN_URL . 'resources/frontend/js/convertkit.js?ver=' . CKGF_PLUGIN_VERSION . "'></script>"; // phpcs:ignore
 		$script .= "<script type='text/javascript'>/* <![CDATA[ */var convertkit = {\"ajaxurl\":\"" . admin_url( 'admin-ajax.php' ) . '"};/* ]]> */</script>'; // phpcs:ignore
 
 		$body = str_replace( '</head>', '</head>' . $script, $body );
@@ -846,9 +846,9 @@ class CKGF_API {
 	 *
 	 * This isn't specifically an API function, but for now it's best suited here.
 	 *
-	 * @param   string $url    URL of Form or Landing Page.
+	 * @param   string $url    		URL of Form or Landing Page.
 	 * @param   bool   $body_only   Return HTML between <body> and </body> tags only.
-	 * @return  string          HTML
+	 * @return  WP_Error|string 	HTML
 	 */
 	private function get_html( $url, $body_only = true ) {
 
@@ -938,11 +938,11 @@ class CKGF_API {
 	 * Converts any relative URls to absolute, fully qualified HTTP(s) URLs for the given
 	 * DOM Elements.
 	 *
-	 * @since   1.2.1
+	 * @since   1.9.6
 	 *
-	 * @param   array  $elements   Elements.
-	 * @param   string $attribute  HTML Attribute.
-	 * @param   string $url        Absolute URL to prepend to relative URLs.
+	 * @param   DOMNodeList<DOMElement> $elements   Elements.
+	 * @param   string                  $attribute  HTML Attribute.
+	 * @param   string                  $url        Absolute URL to prepend to relative URLs.
 	 */
 	private function convert_relative_to_absolute_urls( $elements, $attribute, $url ) {
 
@@ -1117,6 +1117,17 @@ class CKGF_API {
 					)
 				);
 				break;
+
+			default:
+				$result = new WP_Error(
+					'convertkit_api_error',
+					sprintf(
+						/* translators: HTTP method */
+						__( 'API request method %s is not supported in ConvertKit_API class.', 'convertkit' ),
+						$method
+					)
+				);
+				break;
 		}
 
 		// If an error occured, return it now.
@@ -1173,6 +1184,8 @@ class CKGF_API {
 	 * @return string User Agent
 	 */
 	private function get_user_agent() {
+
+		global $wp_version;
 
 		// Include an unmodified $wp_version.
 		require ABSPATH . WPINC . '/version.php';

--- a/includes/class-ckgf-api.php
+++ b/includes/class-ckgf-api.php
@@ -744,31 +744,6 @@ class CKGF_API {
 	}
 
 	/**
-	 * Backward compat. function for updating Forms, Landing Pages and Tags in WordPress options table.
-	 *
-	 * @since   1.0.0
-	 *
-	 * @param   string $api_key    API Key.
-	 * @param   string $api_secret API Secret.
-	 */
-	public function update_resources( $api_key, $api_secret ) { // phpcs:ignore
-
-		// Warn the developer that they shouldn't use this function.
-		_deprecated_function( __FUNCTION__, '1.2.1', 'refresh() in ConvertKit_Resource_Forms, ConvertKit_Resource_Landing_Pages and ConvertKit_Resource_Tags classes.' );
-
-		// Initialize resource classes.
-		$forms         = new ConvertKit_Resource_Forms();
-		$landing_pages = new ConvertKit_Resource_Landing_Pages();
-		$tags          = new ConvertKit_Resource_Tags();
-
-		// Refresh resources by calling the API and storing the results.
-		$forms->refresh();
-		$landing_pages->refresh();
-		$tags->refresh();
-
-	}
-
-	/**
 	 * Backward compat. function for getting a ConvertKit subscriber by their ID.
 	 *
 	 * @since   1.2.1

--- a/includes/class-ckgf-api.php
+++ b/includes/class-ckgf-api.php
@@ -63,7 +63,7 @@ class CKGF_API {
 	 *
 	 * @param   bool|string $api_key        ConvertKit API Key.
 	 * @param   bool|string $api_secret     ConvertKit API Secret.
-	 * @param   bool  		$debug          Save data to log.
+	 * @param   bool        $debug          Save data to log.
 	 */
 	public function __construct( $api_key = false, $api_secret = false, $debug = false ) {
 
@@ -399,7 +399,7 @@ class CKGF_API {
 		 * @since   1.9.6
 		 *
 		 * @param   array   $response   API Response
-		 * @param   int  	$tag_id     Tag ID
+		 * @param   int     $tag_id     Tag ID
 		 * @param   string  $email      Email Address
 		 * @param   mixed   $fields     Custom Fields (false|array).
 		 */
@@ -846,9 +846,9 @@ class CKGF_API {
 	 *
 	 * This isn't specifically an API function, but for now it's best suited here.
 	 *
-	 * @param   string $url    		URL of Form or Landing Page.
+	 * @param   string $url         URL of Form or Landing Page.
 	 * @param   bool   $body_only   Return HTML between <body> and </body> tags only.
-	 * @return  WP_Error|string 	HTML
+	 * @return  WP_Error|string     HTML
 	 */
 	private function get_html( $url, $body_only = true ) {
 

--- a/includes/class-gfconvertkit.php
+++ b/includes/class-gfconvertkit.php
@@ -52,7 +52,8 @@ class GFConvertKit extends GFFeedAddOn {
 	 *
 	 * @var     string
 	 */
-	protected $_path = CKGF_PLUGIN_BASENAME; // phpcs:ignore @phpstan-ignore-line.
+	// @phpstan-ignore-next-line
+	protected $_path = CKGF_PLUGIN_BASENAME; // phpcs:ignore
 
 	/**
 	 * Holds the full path to this Plugin.
@@ -70,7 +71,8 @@ class GFConvertKit extends GFFeedAddOn {
 	 *
 	 * @var     string
 	 */
-	protected $_title = CKGF_TITLE; // phpcs:ignore @phpstan-ignore-line.
+	// @phpstan-ignore-next-line
+	protected $_title = CKGF_TITLE; // phpcs:ignore
 
 	/**
 	 * Holds the short title of this Plugin.
@@ -79,10 +81,11 @@ class GFConvertKit extends GFFeedAddOn {
 	 *
 	 * @var     string
 	 */
-	protected $_short_title = CKGF_SHORT_TITLE; // phpcs:ignore @phpstan-ignore-line.
+	// @phpstan-ignore-next-line
+	protected $_short_title = CKGF_SHORT_TITLE; // phpcs:ignore
 
 	/**
-	 * Holds a list of capabilities to add to roles for Members plugin (https://wordpress.org/plugins/members/) integration. L
+	 * Holds a list of capabilities to add to roles for Members plugin (https://wordpress.org/plugins/members/) integration.
 	 *
 	 * @since   1.2.1
 	 *
@@ -632,7 +635,8 @@ class GFConvertKit extends GFFeedAddOn {
 	 *
 	 * @param   array $feed   ConvertKit Feed.
 	 * @param   array $entry  Gravity Forms Entry / Submission.
-	 * @return  array|null 	  Returns a modified entry object or null.
+	 * @param   array $form   Gravity Forms Form.
+	 * @return  array|null    Returns a modified entry object or null.
 	 */
 	public function process_feed( $feed, $entry, $form ) {
 
@@ -791,7 +795,7 @@ class GFConvertKit extends GFFeedAddOn {
 	 * @since   1.2.1
 	 *
 	 * @param   string $tag_name    Tag Name.
-	 * @return  WP_Error|bool|int 	Tag ID
+	 * @return  WP_Error|bool|int   Tag ID
 	 */
 	private function process_feed_tag( $tag_name ) {
 

--- a/includes/class-gfconvertkit.php
+++ b/includes/class-gfconvertkit.php
@@ -52,7 +52,7 @@ class GFConvertKit extends GFFeedAddOn {
 	 *
 	 * @var     string
 	 */
-	protected $_path = CKGF_PLUGIN_BASENAME; // phpcs:ignore
+	protected $_path = CKGF_PLUGIN_BASENAME; // phpcs:ignore @phpstan-ignore-line.
 
 	/**
 	 * Holds the full path to this Plugin.
@@ -70,7 +70,7 @@ class GFConvertKit extends GFFeedAddOn {
 	 *
 	 * @var     string
 	 */
-	protected $_title = CKGF_TITLE; // phpcs:ignore
+	protected $_title = CKGF_TITLE; // phpcs:ignore @phpstan-ignore-line.
 
 	/**
 	 * Holds the short title of this Plugin.
@@ -79,7 +79,7 @@ class GFConvertKit extends GFFeedAddOn {
 	 *
 	 * @var     string
 	 */
-	protected $_short_title = CKGF_SHORT_TITLE; // phpcs:ignore
+	protected $_short_title = CKGF_SHORT_TITLE; // phpcs:ignore @phpstan-ignore-line.
 
 	/**
 	 * Holds a list of capabilities to add to roles for Members plugin (https://wordpress.org/plugins/members/) integration. L
@@ -307,7 +307,7 @@ class GFConvertKit extends GFFeedAddOn {
 		// by Gravity Forms.
 		if ( is_wp_error( $forms ) ) {
 			$this->set_field_error( $field, $forms->get_error_message() );
-			return;
+			return false;
 		}
 
 		return true;
@@ -336,7 +336,7 @@ class GFConvertKit extends GFFeedAddOn {
 	 * @since   1.0.0
 	 *
 	 * @param   array $feed   ConvertKit Feed.
-	 * @return  array
+	 * @return  string
 	 */
 	public function get_column_value_form_id( $feed ) {
 
@@ -632,7 +632,7 @@ class GFConvertKit extends GFFeedAddOn {
 	 *
 	 * @param   array $feed   ConvertKit Feed.
 	 * @param   array $entry  Gravity Forms Entry / Submission.
-	 * @param   array $form   Gravity Forms Form.
+	 * @return  array|null 	  Returns a modified entry object or null.
 	 */
 	public function process_feed( $feed, $entry, $form ) {
 
@@ -658,7 +658,7 @@ class GFConvertKit extends GFFeedAddOn {
 				__( 'Error Subscribing: The field mapped to the email address contains no value.', 'convertkit' ),
 				'error'
 			);
-			return;
+			return null;
 		}
 
 		// If the Email Address isn't actually an email address, bail.
@@ -672,7 +672,7 @@ class GFConvertKit extends GFFeedAddOn {
 				),
 				'error'
 			);
-			return;
+			return null;
 		}
 
 		// Initialize API class.
@@ -736,7 +736,7 @@ class GFConvertKit extends GFFeedAddOn {
 				),
 				'error'
 			);
-			return;
+			return null;
 		}
 
 		// Add success note to Gravity Forms Entry.
@@ -745,6 +745,8 @@ class GFConvertKit extends GFFeedAddOn {
 			__( 'Subscribed to ConvertKit successfully', 'convertkit' ),
 			'success'
 		);
+
+		return null;
 
 	}
 
@@ -768,6 +770,7 @@ class GFConvertKit extends GFFeedAddOn {
 			return $custom_fields;
 		}
 
+		$fields = array();
 		foreach ( $custom_fields as $custom_field ) {
 			// If this Custom Field isn't mapped in the Feed, skip it.
 			if ( ! isset( $convertkit_custom_fields[ $custom_field['key'] ] ) ) {
@@ -788,7 +791,7 @@ class GFConvertKit extends GFFeedAddOn {
 	 * @since   1.2.1
 	 *
 	 * @param   string $tag_name    Tag Name.
-	 * @return  int                 Tag ID
+	 * @return  WP_Error|bool|int 	Tag ID
 	 */
 	private function process_feed_tag( $tag_name ) {
 

--- a/includes/class-wp-ckgf.php
+++ b/includes/class-wp-ckgf.php
@@ -65,7 +65,7 @@ class WP_CKGF {
 	 */
 	public function load_language_files() {
 
-		load_plugin_textdomain( 'convertkit', false, basename( dirname( CKGF_PLUGIN_BASENAME ) ) . '/languages/' );
+		load_plugin_textdomain( 'convertkit', false, basename( dirname( CKGF_PLUGIN_BASENAME ) ) . '/languages/' ); // @phpstan-ignore-line.
 
 	}
 
@@ -78,7 +78,7 @@ class WP_CKGF {
 	 */
 	public static function get_instance() {
 
-		if ( ! isset( self::$instance ) && ! ( self::$instance instanceof self ) ) {
+		if ( ! isset( self::$instance ) && ! ( self::$instance instanceof self ) ) { // @phpstan-ignore-line.
 			self::$instance = new self();
 		}
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -27,8 +27,5 @@ parameters:
     # Ignore the following errors, as PHPStan and PHPStan for WordPress haven't registered symbols for them yet,
     # so they're false positives.
     ignoreErrors:
-        - '#Access to an undefined property WP_Theme::#'
-        - '#Constant WP_MEMORY_LIMIT not found.#'
-        - '#Constant DB_HOST not found.#'
         - '#Constant WPINC not found.#'
-        - '#Function apply_filters invoked with#' # apply_filters() accepted a variable number of parameters, which PHPStan fails to detect
+        - '#of method GFAddOn::add_note#'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,34 @@
+# PHPStan configuration for GitHub Actions.
+
+# Include PHPStan for WordPress configuration.
+includes:
+    - vendor/szepeviktor/phpstan-wordpress/extension.neon
+
+# Parameters
+parameters:
+    # Paths to scan
+    # This should comprise of the base Plugin PHP file, plus directories that contain Plugin PHP files
+    paths:
+        - convertkit.php
+        - includes/
+
+    # Files that include Plugin-specific PHP constants
+    bootstrapFiles:
+        - convertkit.php
+
+    # Location of WordPress installation
+    scanDirectories:
+        - /home/runner/work/convertkit-gravity-forms/convertkit-gravity-forms/wordpress
+
+    # Should not need to edit anything below here
+    # Rule Level: https://phpstan.org/user-guide/rule-levels
+    level: 5
+
+    # Ignore the following errors, as PHPStan and PHPStan for WordPress haven't registered symbols for them yet,
+    # so they're false positives.
+    ignoreErrors:
+        - '#Access to an undefined property WP_Theme::#'
+        - '#Constant WP_MEMORY_LIMIT not found.#'
+        - '#Constant DB_HOST not found.#'
+        - '#Constant WPINC not found.#'
+        - '#Function apply_filters invoked with#' # apply_filters() accepted a variable number of parameters, which PHPStan fails to detect

--- a/phpstan.neon.example
+++ b/phpstan.neon.example
@@ -1,0 +1,34 @@
+# PHPStan configuration for local static analysis.
+
+# Include PHPStan for WordPress configuration.
+includes:
+    - vendor/szepeviktor/phpstan-wordpress/extension.neon
+
+# Parameters
+parameters:
+    # Paths to scan
+    # This should comprise of the base Plugin PHP file, plus directories that contain Plugin PHP files
+    paths:
+        - convertkit.php
+        - includes/
+
+    # Files that include Plugin-specific PHP constants
+    bootstrapFiles:
+        - convertkit.php
+
+    # Location of WordPress installation
+    scanDirectories:
+        - /Users/tim/Local Sites/convertkit-github/app/public
+
+    # Should not need to edit anything below here
+    # Rule Level: https://phpstan.org/user-guide/rule-levels
+    level: 5
+
+    # Ignore the following errors, as PHPStan and PHPStan for WordPress haven't registered symbols for them yet,
+    # so they're false positives.
+    ignoreErrors:
+        - '#Access to an undefined property WP_Theme::#'
+        - '#Constant WP_MEMORY_LIMIT not found.#'
+        - '#Constant DB_HOST not found.#'
+        - '#Constant WPINC not found.#'
+        - '#Function apply_filters invoked with#' # apply_filters() accepted a variable number of parameters, which PHPStan fails to detect


### PR DESCRIPTION
## Summary

[PHPStan](https://phpstan.org/blog/find-bugs-in-your-code-without-writing-tests) performs static analysis on the Plugin's PHP code.  This adds to our tests, PHP Coding Standards and WordPress Coding Standards by ensuring:

- DocBlocks declarations are valid and uniform
- DocBlocks declarations for WordPress `do_action()` and `apply_filters()` calls are valid
- Typehinting variables and return types declared in DocBlocks are correctly cast
- Any unused functions are detected
- Unnecessary checks / code is highlighted for possible removal
- Conditions that do not evaluate can be fixed/removed as necessary

This isn't a replacement for writing tests; rather, an addition to ensure our code continues to meet the high standards expected, reducing ambiguity on how code should be written and ensuring uniformity in what we produce.

Code changes to pass PHPStan's static analysis also included in this PR, given there are not many changes.  These broadly cover:
- Incorrect DocBlock parameter types (e.g. `string` when it is an `int`)
- More accurate DocBlock return types (e.g. `WP_Error|array` instead of `mixed`)

## Testing

Existing tests confirm working functionality of Plugin.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)