### PR TITLE
Use ConvertKit icon for entry notes

### DIFF
--- a/includes/class-gfconvertkit.php
+++ b/includes/class-gfconvertkit.php
@@ -471,6 +471,19 @@ class GFConvertKit extends GFFeedAddOn {
 	}
 
 	/**
+	 * Defines the image to use for notes added to entries by this addon.
+	 *
+	 * @since   1.2.3
+	 *
+	 * @return  string
+	 */
+	public function note_avatar() {
+
+		return CKGF_PLUGIN_URL . 'resources/backend/images/block-icon-form.png';
+
+	}
+
+	/**
 	 * Adds Custom Fields to the Feed Settings Fields, if Custom Fields exist in the ConvertKit account.
 	 *
 	 * @since   1.0.0

--- a/readme.txt
+++ b/readme.txt
@@ -42,6 +42,9 @@ No. You must first have an account on ConvertKit.com, but you do not have to use
 
 == Changelog ==
 
+### 1.2.3 2022-04-xx
+* Added: Form: Entries: Show ConvertKit icon next to Form Entries' Notes
+
 ### 1.2.2 2022-04-05
 * Fix: Updated API Class
 

--- a/tests/_support/Helper/Acceptance.php
+++ b/tests/_support/Helper/Acceptance.php
@@ -432,6 +432,9 @@ class Acceptance extends \Codeception\Module
 		$I->amOnAdminPage('admin.php?page=gf_entries');
 		$I->click('table.gf_entries tbody tr.entry_row:first-child a[aria-label="View this entry"]');
 		$I->seeElementInDOM('#notes div[data-type="ckgf"]');
+
+		// Confirm that the ConvertKit logo is displayed beside the note.
+		$I->seeInSource('<img alt="ConvertKit" src="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-content/plugins/convertkit-gravity-forms/resources/backend/images/block-icon-form.png" class="avatar avatar-48" height="48" width="48">');
 	}
 
 	/**
@@ -445,6 +448,9 @@ class Acceptance extends \Codeception\Module
 		$I->amOnAdminPage('admin.php?page=gf_entries');
 		$I->click('table.gf_entries tbody tr.entry_row:first-child a[aria-label="View this entry"]');
 		$I->seeElementInDOM('#notes div[data-type="ckgf"][data-sub-type="success"]');
+
+		// Confirm that the ConvertKit logo is displayed beside the note.
+		$I->seeInSource('<img alt="ConvertKit" src="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-content/plugins/convertkit-gravity-forms/resources/backend/images/block-icon-form.png" class="avatar avatar-48" height="48" width="48">');
 	}
 
 	/**
@@ -458,6 +464,9 @@ class Acceptance extends \Codeception\Module
 		$I->amOnAdminPage('admin.php?page=gf_entries');
 		$I->click('table.gf_entries tbody tr.entry_row:first-child a[aria-label="View this entry"]');
 		$I->seeElementInDOM('#notes div[data-type="ckgf"][data-sub-type="error"]');
+
+		// Confirm that the ConvertKit logo is displayed beside the note.
+		$I->seeInSource('<img alt="ConvertKit" src="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-content/plugins/convertkit-gravity-forms/resources/backend/images/block-icon-form.png" class="avatar avatar-48" height="48" width="48">');
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Displays the ConvertKit logo / icon for notes added by this Plugin to a Gravity Forms entry.

Before:
![Screenshot 2022-04-14 at 13 19 41](https://user-images.githubusercontent.com/1462305/163395870-4744f777-31a8-4836-ba7c-b820a1c7e58a.png)

After:
![Screenshot 2022-04-14 at 13 19 49](https://user-images.githubusercontent.com/1462305/163395890-1882aa53-854c-4050-8524-a42804b5e61b.png)

## Testing

- Added check to `checkGravityFormsNotesExist`, `checkGravityFormsSuccessNotesExist` and `checkGravityFormsErrorNotesExist` helper functions to confirm that the ConvertKit logo is displayed.

## Checklist

* [x] I have [written a test](https://github.com/ConvertKit/convertkit-wordpress/blob/master/TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](https://github.com/ConvertKit/convertkit-wordpress/blob/master/TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](https://github.com/ConvertKit/convertkit-wordpress/blob/master/TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](https://github.com/ConvertKit/convertkit-wordpress/blob/master/DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](https://github.com/ConvertKit/convertkit-wordpress/blob/master/DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)