### PR TITLE
Testing: Support for Gravity Forms 2.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
     # For PHP, make sure that an nginx configuration file exists for the required PHP version in this repository at tests/nginx/php-x.x.conf
     strategy:
       matrix:
-        wp-versions: [ '5.9.2' ] #[ '5.6.7', '5.7.5', '5.8.3', '5.9' ]
+        wp-versions: [ '5.9.3' ] #[ '5.6.7', '5.7.5', '5.8.3', '5.9' ]
         php-versions: [ '7.2', '7.3', '7.4', '8.0' ] #[ '7.3', '7.4', '8.0', '8.1' ]
 
     # Steps to install, configure and run tests
@@ -172,13 +172,10 @@ jobs:
 
       # This ensures the Plugin's log file can be written to.
       # We don't recursively do this, as it'll prevent Codeception from writing to the /tests/_output directory.
-      - name: Set chmod for Plugin Directory
-        run: sudo chmod g+w ${{ env.PLUGIN_DIR }}
-
-      # This ensures the Plugin's log file can be written to.
-      # We don't recursively do this, as it'll prevent Codeception from writing to the /tests/_output directory.
-      - name: Set chown for Plugin Directory
-        run: sudo chown www-data:www-data ${{ env.PLUGIN_DIR }}
+      - name: Set Permissions for Plugin Directory
+        run: |
+          sudo chmod g+w ${{ env.PLUGIN_DIR }}
+          sudo chown www-data:www-data ${{ env.PLUGIN_DIR }}
 
       # We run these before the main tests, as typically CodeSniffer is fast. If there's a failure, we can tell
       # the user sooner.

--- a/tests/_support/Helper/Acceptance.php
+++ b/tests/_support/Helper/Acceptance.php
@@ -265,16 +265,24 @@ class Acceptance extends \Codeception\Module
 		$I->click('#add_standard_fields button[data-type="textarea"]');
 		$I->wait(2);
 
-		// Add Select Field, with values matching ConvertKit Tags.
+		// Add Select Field.
 		$I->click('#add_standard_fields button[data-type="select"]');
 		$I->wait(2);
 
-		$I->click('#field_5');
+		// Click the Select Field.
+		$I->click('#field_6');
 		$I->wait(2);
 
 		$I->fillField('#field_label', 'Tag');
-		$I->click('label[for=field_choice_values_enabled]');
+
+		// Open Choices flyout.
+		$I->click('button.choices-ui__trigger');
+		$I->wait(2);
+
+		// Show Values.
+		$I->click('#choices-ui-flyout .gform-flyout__body label[for=field_choice_values_enabled]');
 		
+		// Define Tags.
 		$I->fillField('#select_choice_text_0', 'Select Tag');
 		$I->fillField('#select_choice_value_0', '');
 		
@@ -283,6 +291,9 @@ class Acceptance extends \Codeception\Module
 
 		$I->fillField('#select_choice_text_2', 'Tag Label 2');
 		$I->fillField('#select_choice_value_2', 'fakeTagNotInConvertKit');
+
+		// Close Choices flyout.
+		$I->click('#choices-ui-flyout .gform-flyout__close');
 	
 		// Update.
 		$I->click('button.update-form');


### PR DESCRIPTION
## Summary

Updates acceptance tests when creating a Gravity Form to support how Gravity Forms 2.6 select dropdown values are defined in the form editor UI, compared to 2.5 and earlier.

## Testing

- `createGravityFormsForm` helper function updated to support defining select dropdown options in Gravity Forms 2.6's form editor UI.

## Checklist

* [x] I have [written a test](https://github.com/ConvertKit/convertkit-wordpress/blob/master/TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](https://github.com/ConvertKit/convertkit-wordpress/blob/master/TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](https://github.com/ConvertKit/convertkit-wordpress/blob/master/TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](https://github.com/ConvertKit/convertkit-wordpress/blob/master/DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](https://github.com/ConvertKit/convertkit-wordpress/blob/master/DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)