### PR TITLE
Fix PHPStan Configuration

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -16,9 +16,9 @@ parameters:
     bootstrapFiles:
         - convertkit.php
 
-    # Location of WordPress installation
+    # Location of WordPress Plugins for PHPStan to scan, building symbols.
     scanDirectories:
-        - /home/runner/work/convertkit-gravity-forms/convertkit-gravity-forms/wordpress
+        - /home/runner/work/convertkit-gravity-forms/convertkit-gravity-forms/wordpress/wp-content/plugins
 
     # Should not need to edit anything below here
     # Rule Level: https://phpstan.org/user-guide/rule-levels

--- a/phpstan.neon.example
+++ b/phpstan.neon.example
@@ -16,9 +16,9 @@ parameters:
     bootstrapFiles:
         - convertkit.php
 
-    # Location of WordPress installation
+    # Location of WordPress Plugins for PHPStan to scan, building symbols.
     scanDirectories:
-        - /Users/tim/Local Sites/convertkit-github/app/public
+        - /Users/tim/Local Sites/convertkit-github/app/public/wp-content/plugins
 
     # Should not need to edit anything below here
     # Rule Level: https://phpstan.org/user-guide/rule-levels
@@ -27,8 +27,4 @@ parameters:
     # Ignore the following errors, as PHPStan and PHPStan for WordPress haven't registered symbols for them yet,
     # so they're false positives.
     ignoreErrors:
-        - '#Access to an undefined property WP_Theme::#'
-        - '#Constant WP_MEMORY_LIMIT not found.#'
-        - '#Constant DB_HOST not found.#'
-        - '#Constant WPINC not found.#'
-        - '#Function apply_filters invoked with#' # apply_filters() accepted a variable number of parameters, which PHPStan fails to detect
+        - '#of method GFAddOn::add_note#'


### PR DESCRIPTION
## Summary

Fixes PHPStan's configuration for GitHub actions by:
- Changing `scanDirectories` to scan the WordPress Plugins directory to build symbols (function definitions and constants), rather than scanning the entire WordPress installation, because the `includes` configuration already points to phpstan-wordpress' WordPress symbol definitions.  Scanning the entire WordPress installation is slower and results in [false positive errors](https://github.com/ConvertKit/convertkit-gravity-forms/runs/6817912437?check_suite_focus=true).
- Changing `ignoreErrors` to ignore some Gravity Forms symbols that aren't yet detected by PHPStan.

## Testing

Existing tests should pass to confirm this PR works.

## Checklist

* [x] I have [written a test](https://github.com/ConvertKit/convertkit-wordpress/blob/master/TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](https://github.com/ConvertKit/convertkit-wordpress/blob/master/TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](https://github.com/ConvertKit/convertkit-wordpress/blob/master/TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](https://github.com/ConvertKit/convertkit-wordpress/blob/master/DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](https://github.com/ConvertKit/convertkit-wordpress/blob/master/DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)