### PR TITLE
Improve reasons to ignore coding standards

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -181,7 +181,7 @@ jobs:
       # the user sooner.
       - name: Run WordPress Coding Standards Tests
         working-directory: ${{ env.PLUGIN_DIR }}
-        run: php vendor/bin/phpcs ./ -v
+        run: php vendor/bin/phpcs ./ -v -s
 
       # Run PHPStan for static analysis.
       - name: Run PHPStan Static Analysis

--- a/convertkit.php
+++ b/convertkit.php
@@ -47,7 +47,7 @@ require_once CKGF_PLUGIN_PATH . '/includes/class-wp-ckgf.php';
  *
  * @since   1.2.1
  */
-function WP_CKGF() { // phpcs:ignore
+function WP_CKGF() { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName
 
 	return WP_CKGF::get_instance();
 
@@ -58,7 +58,7 @@ function WP_CKGF() { // phpcs:ignore
  *
  * @since   1.2.1
  */
-function WP_CKGF_Integration() { // phpcs:ignore
+function WP_CKGF_Integration() { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName
 
 	return GFConvertKit::get_instance();
 

--- a/includes/class-gfconvertkit.php
+++ b/includes/class-gfconvertkit.php
@@ -23,7 +23,7 @@ class GFConvertKit extends GFFeedAddOn {
 	 *
 	 * @var     string
 	 */
-	protected $_version = CKGF_PLUGIN_VERSION; // phpcs:ignore
+	protected $_version = CKGF_PLUGIN_VERSION; // phpcs:ignore PSR2.Classes.PropertyDeclaration.Underscore
 
 	/**
 	 * Holds the minimum required Gravity Forms version for this integration
@@ -33,7 +33,7 @@ class GFConvertKit extends GFFeedAddOn {
 	 *
 	 * @var     string
 	 */
-	protected $_min_gravityforms_version = CKGF_MIN_GF_VERSION; // phpcs:ignore
+	protected $_min_gravityforms_version = CKGF_MIN_GF_VERSION; // phpcs:ignore PSR2.Classes.PropertyDeclaration.Underscore
 
 	/**
 	 * Holds the slug that stores settings and is used for referencing
@@ -43,7 +43,7 @@ class GFConvertKit extends GFFeedAddOn {
 	 *
 	 * @var     string
 	 */
-	protected $_slug = CKGF_SLUG; // phpcs:ignore
+	protected $_slug = CKGF_SLUG; // phpcs:ignore PSR2.Classes.PropertyDeclaration.Underscore
 
 	/**
 	 * Holds the path and filename to the Plugin.
@@ -51,9 +51,9 @@ class GFConvertKit extends GFFeedAddOn {
 	 * @since   1.0.0
 	 *
 	 * @var     string
+	 * @phpstan-ignore-next-line
 	 */
-	// @phpstan-ignore-next-line
-	protected $_path = CKGF_PLUGIN_BASENAME; // phpcs:ignore
+	protected $_path = CKGF_PLUGIN_BASENAME; // phpcs:ignore PSR2.Classes.PropertyDeclaration.Underscore
 
 	/**
 	 * Holds the full path to this Plugin.
@@ -62,7 +62,7 @@ class GFConvertKit extends GFFeedAddOn {
 	 *
 	 * @var     string
 	 */
-	protected $_full_path = CKGF_PLUGIN_FILEPATH; // phpcs:ignore
+	protected $_full_path = CKGF_PLUGIN_FILEPATH; // phpcs:ignore PSR2.Classes.PropertyDeclaration.Underscore
 
 	/**
 	 * Holds the full title of this Plugin.
@@ -70,9 +70,9 @@ class GFConvertKit extends GFFeedAddOn {
 	 * @since   1.0.0
 	 *
 	 * @var     string
+	 * @phpstan-ignore-next-line
 	 */
-	// @phpstan-ignore-next-line
-	protected $_title = CKGF_TITLE; // phpcs:ignore
+	protected $_title = CKGF_TITLE; // phpcs:ignore PSR2.Classes.PropertyDeclaration.Underscore
 
 	/**
 	 * Holds the short title of this Plugin.
@@ -80,9 +80,9 @@ class GFConvertKit extends GFFeedAddOn {
 	 * @since   1.0.0
 	 *
 	 * @var     string
+	 * @phpstan-ignore-next-line
 	 */
-	// @phpstan-ignore-next-line
-	protected $_short_title = CKGF_SHORT_TITLE; // phpcs:ignore
+	protected $_short_title = CKGF_SHORT_TITLE; // phpcs:ignore PSR2.Classes.PropertyDeclaration.Underscore
 
 	/**
 	 * Holds a list of capabilities to add to roles for Members plugin (https://wordpress.org/plugins/members/) integration.
@@ -91,7 +91,7 @@ class GFConvertKit extends GFFeedAddOn {
 	 *
 	 * @var     array
 	 */
-	protected $_capabilities = array( 'ckgf_convertkit', 'ckgf_convertkit_uninstall' ); // phpcs:ignore
+	protected $_capabilities = array( 'ckgf_convertkit', 'ckgf_convertkit_uninstall' ); // phpcs:ignore PSR2.Classes.PropertyDeclaration.Underscore
 
 	/**
 	 * Holds capabilities or roles that have access to this Plugin's Settings page.
@@ -100,7 +100,7 @@ class GFConvertKit extends GFFeedAddOn {
 	 *
 	 * @var     string
 	 */
-	protected $_capabilities_settings_page = 'ckgf_convertkit_settings_page'; // phpcs:ignore
+	protected $_capabilities_settings_page = 'ckgf_convertkit_settings_page'; // phpcs:ignore PSR2.Classes.PropertyDeclaration.Underscore
 
 	/**
 	 * Holds capabilities or roles that have access to this Plugin's Form Settings page.
@@ -109,7 +109,7 @@ class GFConvertKit extends GFFeedAddOn {
 	 *
 	 * @var     string
 	 */
-	protected $_capabilities_form_page = 'ckgf_convertkit_form_page'; // phpcs:ignore
+	protected $_capabilities_form_page = 'ckgf_convertkit_form_page'; // phpcs:ignore PSR2.Classes.PropertyDeclaration.Underscore
 
 	/**
 	 * Holds capabilities or roles that can install this Plugin.
@@ -118,7 +118,7 @@ class GFConvertKit extends GFFeedAddOn {
 	 *
 	 * @var     string
 	 */
-	protected $_capabilities_uninstall = 'ckgf_convertkit_uninstall'; // phpcs:ignore
+	protected $_capabilities_uninstall = 'ckgf_convertkit_uninstall'; // phpcs:ignore PSR2.Classes.PropertyDeclaration.Underscore
 
 	/**
 	 * Holds the class object.
@@ -127,7 +127,7 @@ class GFConvertKit extends GFFeedAddOn {
 	 *
 	 * @var     object
 	 */
-	private static $_instance = null; // phpcs:ignore
+	private static $_instance = null; // phpcs:ignore PSR2.Classes.PropertyDeclaration.Underscore
 
 	/**
 	 * Holds the API instance.

--- a/lib/class-convertkit-api.php
+++ b/lib/class-convertkit-api.php
@@ -942,10 +942,13 @@ class ConvertKit_API {
 		$body = $this->get_html( $url, false );
 
 		// Inject JS for subscriber forms to work.
+		// wp_enqueue_script() isn't called when we load a Landing Page, so we can't use it.
+		// phpcs:disable WordPress.WP.EnqueuedResources
 		$scripts = new WP_Scripts();
-		$script  = "<script type='text/javascript' src='" . trailingslashit( $scripts->base_url ) . "wp-includes/js/jquery/jquery.js?ver=1.4.0'></script>"; // phpcs:ignore
-		$script .= "<script type='text/javascript' src='" . $this->plugin_url . 'resources/frontend/js/convertkit.js?ver=' . $this->plugin_version . "'></script>"; // phpcs:ignore
-		$script .= "<script type='text/javascript'>/* <![CDATA[ */var convertkit = {\"ajaxurl\":\"" . admin_url( 'admin-ajax.php' ) . '"};/* ]]> */</script>'; // phpcs:ignore
+		$script  = "<script type='text/javascript' src='" . trailingslashit( $scripts->base_url ) . "wp-includes/js/jquery/jquery.js?ver=1.4.0'></script>";
+		$script .= "<script type='text/javascript' src='" . $this->plugin_url . 'resources/frontend/js/convertkit.js?ver=' . $this->plugin_version . "'></script>";
+		$script .= "<script type='text/javascript'>/* <![CDATA[ */var convertkit = {\"ajaxurl\":\"" . admin_url( 'admin-ajax.php' ) . '"};/* ]]> */</script>';
+		// phpcs:enable
 
 		$body = str_replace( '</head>', '</head>' . $script, $body );
 
@@ -963,7 +966,7 @@ class ConvertKit_API {
 	 */
 	public function purchase_create( $purchase ) {
 
-		$this->log( 'API: purchase_create(): [ purchase: ' . print_r( $purchase, true ) . ']' ); // phpcs:ignore
+		$this->log( 'API: purchase_create(): [ purchase: ' . print_r( $purchase, true ) . ']' ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions
 
 		$response = $this->post(
 			'purchases',

--- a/lib/class-convertkit-log.php
+++ b/lib/class-convertkit-log.php
@@ -111,7 +111,7 @@ class ConvertKit_Log {
 		}
 
 		// Open log file.
-		$log = $wp_filesystem->get_contents_array( $this->get_filename() ); // phpcs:ignore
+		$log = $wp_filesystem->get_contents_array( $this->get_filename() );
 
 		// Bail if the log file is empty.
 		if ( ! is_array( $log ) || ! count( $log ) ) {


### PR DESCRIPTION
## Summary

Replaces `phpcs:ignore` comments with the specific rule to ignore, such as `phpcs:ignore PSR2.Classes.PropertyDeclaration.Underscore`.

This ensures the coding standard checks for lines containing an ignore directive will still validate the code against other coding standard rules.

## Testing

Existing tests pass to confirm no breaking changes.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)