### PR TITLE
Rename, Fix and Test Capabilities

### DIFF
--- a/includes/class-gfconvertkit.php
+++ b/includes/class-gfconvertkit.php
@@ -91,7 +91,7 @@ class GFConvertKit extends GFFeedAddOn {
 	 *
 	 * @var     array
 	 */
-	protected $_capabilities = array( 'ckgf_convertkit', 'ckgf_convertkit_uninstall' ); // phpcs:ignore
+	protected $_capabilities = array( 'ckgf_convertkit_settings_page', 'ckgf_convertkit_form_page', 'ckgf_convertkit_uninstall' ); // phpcs:ignore
 
 	/**
 	 * Holds capabilities or roles that have access to this Plugin's Settings page.
@@ -105,11 +105,11 @@ class GFConvertKit extends GFFeedAddOn {
 	/**
 	 * Holds capabilities or roles that have access to this Plugin's Form Settings page.
 	 *
-	 * @since   1.2.1
+	 * @since   1.2.5
 	 *
 	 * @var     string
 	 */
-	protected $_capabilities_form_page = 'ckgf_convertkit_form_page'; // phpcs:ignore
+	protected $_capabilities_form_settings = 'ckgf_convertkit_form_page'; // phpcs:ignore
 
 	/**
 	 * Holds capabilities or roles that can install this Plugin.

--- a/readme.txt
+++ b/readme.txt
@@ -42,6 +42,9 @@ No. You must first have an account on ConvertKit.com, but you do not have to use
 
 == Changelog ==
 
+### 1.2.5 2022-07-xx
+* Fix: Capabilities: Correctly define capabilities for add-on settings, form settings and uninstall action
+
 ### 1.2.4 2022-06-23
 * Added: Support for WordPress 6.0
 

--- a/tests/_support/Helper/Acceptance/GravityForms.php
+++ b/tests/_support/Helper/Acceptance/GravityForms.php
@@ -276,4 +276,51 @@ class GravityForms extends \Codeception\Module
 		$I->click('table.gf_entries tbody tr.entry_row:first-child a[aria-label="View this entry"]');
 		$I->dontSeeElementInDOM('#notes div[data-type="ckgf"]');
 	}
+
+	/**
+	 * Creates a role called 'gravity_forms'.
+	 * 
+	 * If the role exists, deletes it before creating.
+	 * 
+	 * @since 	1.2.5
+	 * 
+	 * @param 	AcceptanceTester 	$I 			Tester
+	 * @param 	bool 				$settings 	Role has access to Plugin's Settings
+	 * @param 	bool 				$form 		Role has access to Plugin's Form Settings
+	 * @param 	bool 				$uninstall 	Role has access to Plugin's Uninstallation action
+	 */
+	public function createGravityFormsRole($I, $settings = true, $form = true, $uninstall = true)
+	{
+		$I->deleteRole($I, 'gravity_forms');
+		$I->addRole($I, 'gravity_forms', [
+			// General.
+			'edit_dashboard' => true,
+			'read' => true,
+
+			// Gravity Forms.
+			'gravityforms_api_settings' => true,
+			'gravityforms_create_form' => true,
+			'gravityforms_delete_entries' => true,
+			'gravityforms_delete_forms' => true,
+			'gravityforms_edit_entries' => true,
+			'gravityforms_edit_entry_notes' => true,
+			'gravityforms_edit_forms' => true,
+			'gravityforms_edit_settings' => true,
+			'gravityforms_export_entries' => true,
+			'gravityforms_logging' => true,
+			'gravityforms_preview_forms' => true,
+			'gravityforms_system_status' => true,
+			'gravityforms_uninstall' => true,
+			'gravityforms_view_addons' => true,
+			'gravityforms_view_entries' => true,
+			'gravityforms_view_entry_notes' => true,
+			'gravityforms_view_settings' => true,
+			'gravityforms_view_updates' => true,
+
+			// Plugin.
+			'ckgf_convertkit_settings_page' => $settings,
+			'ckgf_convertkit_form_page' => $form,
+			'ckgf_convertkit_uninstall' => $uninstall,
+		]);
+	}
 }

--- a/tests/_support/Helper/Acceptance/Plugin.php
+++ b/tests/_support/Helper/Acceptance/Plugin.php
@@ -86,5 +86,8 @@ class Plugin extends \Codeception\Module
 		// Review Request.
 		$I->dontHaveOptionInDatabase('convertkit-gravity-forms-review-request');
 		$I->dontHaveOptionInDatabase('convertkit-gravity-forms-review-dismissed');
+
+		// Users.
+		$I->dontHaveUserInDatabase('gravity_forms_user');
 	}
 }

--- a/tests/_support/Helper/Acceptance/Roles.php
+++ b/tests/_support/Helper/Acceptance/Roles.php
@@ -1,0 +1,43 @@
+<?php
+namespace Helper\Acceptance;
+
+// Define any custom actions related to the ConvertKit Plugin that
+// would be used across multiple tests.
+// These are then available in $I->{yourFunctionName}
+
+class Roles extends \Codeception\Module
+{
+	/**
+	 * Helper method add a role to WordPress.
+	 * 
+	 * @since 	1.2.5
+	 * 
+	 * @param 	AcceptanceTester 	$I 				Tester
+	 * @param 	string 				$name 			Programmatic name of Role
+	 * @param 	array 				$capabilities 	Array of capabilites for the Role
+	 */
+	public function addRole($I, $name, $capabilities)
+	{
+		$roles = $I->grabOptionFromDatabase('wp_user_roles');
+		$roles[$name] = [
+			'name' => $name,
+			'capabilities' => $capabilities,
+		];
+		$I->haveOptionInDatabase('wp_user_roles', $roles);
+	}
+
+	/**
+	 * Helper method delete a role from WordPress.
+	 * 
+	 * @since 	1.2.5
+	 * 
+	 * @param 	AcceptanceTester 	$I 				Tester
+	 * @param 	string 				$name 			Programmatic name of Role
+	 */
+	public function deleteRole($I, $name)
+	{
+		$roles = $I->grabOptionFromDatabase('wp_user_roles');
+		unset($roles[$name]);
+		$I->haveOptionInDatabase('wp_user_roles', $roles);
+	}
+}

--- a/tests/acceptance.suite.yml
+++ b/tests/acceptance.suite.yml
@@ -22,6 +22,7 @@ modules:
         - \Helper\Acceptance\Email
         - \Helper\Acceptance\GravityForms
         - \Helper\Acceptance\Plugin
+        - \Helper\Acceptance\Roles
         - \Helper\Acceptance\ThirdPartyPlugin
         - \Helper\Acceptance\Xdebug
     config:

--- a/tests/acceptance/CapabilitiesCest.php
+++ b/tests/acceptance/CapabilitiesCest.php
@@ -232,6 +232,9 @@ class CapabilitiesCest
 	 */
 	public function _passed(AcceptanceTester $I)
 	{
+		// Log back in as an Administrator to perform Plugin deactivation.
+		$I->logOut();
+		$I->loginAsAdmin();
 		$I->deactivateConvertKitPlugin($I);
 		$I->deactivateThirdPartyPlugin($I, 'gravity-forms');
 		$I->resetConvertKitPlugin($I);

--- a/tests/acceptance/CapabilitiesCest.php
+++ b/tests/acceptance/CapabilitiesCest.php
@@ -1,0 +1,239 @@
+<?php
+/**
+ * Tests that a Role's Capabilities are honored when enabled/disabled for:
+ * - Add-On Settings (Forms > Settings > ConvertKit)
+ * - Form Settings (Forms > Edit Form > Settings > ConvertKit)
+ * - Uninstall (Forms > Settings > Uninstall > ConvertKit)
+ * 
+ * @since 	1.2.5
+ */
+class CapabilitiesCest
+{
+	/**
+	 * Run common actions before running the test functions in this class.
+	 * 
+	 * @since 	1.2.5
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function _before(AcceptanceTester $I)
+	{
+		$I->activateConvertKitPlugin($I);
+		$I->activateThirdPartyPlugin($I, 'gravity-forms');
+		$I->setupConvertKitPlugin($I);
+	}
+
+	/**
+	 * Test that a WordPress User assigned a Role with the Add-On Settings capability enabled
+	 * can access the add-on settings screen at Forms > Settings > ConvertKit.
+	 * 
+	 * @since 	1.2.5
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testAddOnSettingsWhenCapabilityEnabledForRole(AcceptanceTester $I)
+	{
+		// Create Role.
+		$I->createGravityFormsRole($I, true, false, false);
+
+		// Create User, assigned to the Role.
+		$I->haveUserInDatabase('gravity_forms_user', 'gravity_forms', [
+			'user_email' 	=> 'gravity_forms_user@test.local',
+			'user_pass' 	=> $_ENV['TEST_SITE_ADMIN_PASSWORD'],
+		]);
+
+		// Logout.
+		$I->logOut();
+
+		// Login as Gravity Forms users.
+		$I->loginAs('gravity_forms_user', $_ENV['TEST_SITE_ADMIN_PASSWORD']);
+
+		// Go to the Plugin's Settings Screen.
+		$I->loadConvertKitSettingsScreen($I);
+
+		// Confirm that an expected settings field displays.
+		$I->seeInSource('<input type="text" name="_gform_setting_api_key"');
+	}
+
+	/**
+	 * Test that a WordPress User assigned a Role with the Add-On Settings capability disabled
+	 * cannot access the add-on settings screen at Forms > Settings > ConvertKit.
+	 * 
+	 * @since 	1.2.5
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testAddOnSettingsWhenCapabilityDisabledForRole(AcceptanceTester $I)
+	{
+		// Create Role.
+		$I->createGravityFormsRole($I, false, false, false);
+
+		// Create User, assigned to the Role.
+		$I->haveUserInDatabase('gravity_forms_user', 'gravity_forms', [
+			'user_email' 	=> 'gravity_forms_user@test.local',
+			'user_pass' 	=> $_ENV['TEST_SITE_ADMIN_PASSWORD'],
+		]);
+
+		// Logout.
+		$I->logOut();
+
+		// Login as Gravity Forms users.
+		$I->loginAs('gravity_forms_user', $_ENV['TEST_SITE_ADMIN_PASSWORD']);
+
+		// Go to the Plugin's Settings Screen.
+		$I->loadConvertKitSettingsScreen($I);
+
+		// Confirm that an expected settings field displays.
+		$I->dontSeeInSource('<input type="text" name="_gform_setting_api_key"');
+	}
+
+	/**
+	 * Test that a WordPress User assigned a Role with the Form Settings capability enabled
+	 * can access the add-on settings screen at Forms > Edit Form > Settings > ConvertKit.
+	 * 
+	 * @since 	1.2.5
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testFormSettingsWhenCapabilityEnabledForRole(AcceptanceTester $I)
+	{
+		// Create Role.
+		$I->createGravityFormsRole($I, false, true, false);
+
+		// Create User, assigned to the Role.
+		$I->haveUserInDatabase('gravity_forms_user', 'gravity_forms', [
+			'user_email' 	=> 'gravity_forms_user@test.local',
+			'user_pass' 	=> $_ENV['TEST_SITE_ADMIN_PASSWORD'],
+		]);
+
+		// Logout.
+		$I->logOut();
+
+		// Login as Gravity Forms users.
+		$I->loginAs('gravity_forms_user', $_ENV['TEST_SITE_ADMIN_PASSWORD']);
+
+		// Create Form.
+		$gravityFormID = $I->createGravityFormsForm($I);
+
+		// Go to the Form's Settings Screen.
+		$I->amOnAdminPage('admin.php?page=gf_edit_forms&view=settings&subview=ckgf&id='.$gravityFormID);
+
+		// Confirm that ConvertKit Feeds are displayed.
+		$I->seeInSource('ConvertKit Feeds');
+	}
+
+	/**
+	 * Test that a WordPress User assigned a Role with the Form Settings capability disabled
+	 * cannot access the add-on settings screen at Forms > Edit Form > Settings > ConvertKit.
+	 * 
+	 * @since 	1.2.5
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testFormSettingsWhenCapabilityDisabledForRole(AcceptanceTester $I)
+	{
+		// Create Role.
+		$I->createGravityFormsRole($I, false, false, false);
+
+		// Create User, assigned to the Role.
+		$I->haveUserInDatabase('gravity_forms_user', 'gravity_forms', [
+			'user_email' 	=> 'gravity_forms_user@test.local',
+			'user_pass' 	=> $_ENV['TEST_SITE_ADMIN_PASSWORD'],
+		]);
+
+		// Logout.
+		$I->logOut();
+
+		// Login as Gravity Forms users.
+		$I->loginAs('gravity_forms_user', $_ENV['TEST_SITE_ADMIN_PASSWORD']);
+
+		// Create Form.
+		$gravityFormID = $I->createGravityFormsForm($I);
+
+		// Go to the Form's Settings Screen.
+		$I->amOnAdminPage('admin.php?page=gf_edit_forms&view=settings&subview=ckgf&id='.$gravityFormID);
+
+		// Confirm that ConvertKit Feeds are displayed.
+		$I->dontSeeInSource('ConvertKit Feeds');
+	}
+
+	/**
+	 * Test that a WordPress User assigned a Role with the Uninstall capability enabled
+	 * can access the add-on uninstall functionality at Forms > Settings > Uninstall.
+	 * 
+	 * @since 	1.2.5
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testUninstallWhenCapabilityEnabledForRole(AcceptanceTester $I)
+	{
+		// Create Role.
+		$I->createGravityFormsRole($I, false, false, true);
+
+		// Create User, assigned to the Role.
+		$I->haveUserInDatabase('gravity_forms_user', 'gravity_forms', [
+			'user_email' 	=> 'gravity_forms_user@test.local',
+			'user_pass' 	=> $_ENV['TEST_SITE_ADMIN_PASSWORD'],
+		]);
+
+		// Logout.
+		$I->logOut();
+
+		// Login as Gravity Forms users.
+		$I->loginAs('gravity_forms_user', $_ENV['TEST_SITE_ADMIN_PASSWORD']);
+
+		// Go to the Settings > Uninstall Screen.
+		$I->amOnAdminPage('admin.php?page=gf_settings&subview=uninstall');
+
+		// Confirm that the uninstall option for this Plugin is displayed.
+		$I->seeInSource('This operation deletes ALL ConvertKit settings.');
+	}
+
+	/**
+	 * Test that a WordPress User assigned a Role with the Uninstall capability disabled
+	 * cannot access the add-on uninstall functionality at Forms > Settings > Uninstall.
+	 * 
+	 * @since 	1.2.5
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testUninstallWhenCapabilityDisabledForRole(AcceptanceTester $I)
+	{
+		// Create Role.
+		$I->createGravityFormsRole($I, false, false, false);
+
+		// Create User, assigned to the Role.
+		$I->haveUserInDatabase('gravity_forms_user', 'gravity_forms', [
+			'user_email' 	=> 'gravity_forms_user@test.local',
+			'user_pass' 	=> $_ENV['TEST_SITE_ADMIN_PASSWORD'],
+		]);
+
+		// Logout.
+		$I->logOut();
+
+		// Login as Gravity Forms users.
+		$I->loginAs('gravity_forms_user', $_ENV['TEST_SITE_ADMIN_PASSWORD']);
+
+		// Go to the Settings > Uninstall Screen.
+		$I->amOnAdminPage('admin.php?page=gf_settings&subview=uninstall');
+
+		// Confirm that the uninstall option for this Plugin is displayed.
+		$I->dontSeeInSource('This operation deletes ALL ConvertKit settings.');
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 * 
+	 * @since 	1.2.2
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->deactivateConvertKitPlugin($I);
+		$I->deactivateThirdPartyPlugin($I, 'gravity-forms');
+		$I->resetConvertKitPlugin($I);
+	}
+}


### PR DESCRIPTION
## Summary

Renames the Form Settings capability from the incorrect `$_capabilities_form_page` to the correct `$_capabilities_form_settings`, as reported [here](https://wordpress.org/support/topic/capabilities-bug-2/).

### Detail

Capabilities are assigned to WordPress Roles, and determine what a Role can and cannot do in WordPress.
![Screenshot 2022-07-18 at 12 14 20](https://user-images.githubusercontent.com/1462305/179499943-9f6cbbfe-f740-4eae-99c5-5bad6a9b5548.png)

Roles, in turn, are assigned to WordPress Users, which determines what a User can and cannot do in WordPress.

For Gravity Forms, it's possible to register three capabilities, that non-Administrator Roles can have assigned to them (Administrators always have access to all capabilities by default):
- `ckgf_convertkit_settings_page`: Permits the Role access to the Plugin's Settings page at Forms > Settings > ConvertKit
![Screenshot 2022-07-18 at 12 14 55](https://user-images.githubusercontent.com/1462305/179499964-56a2e583-79a7-436e-b08e-9c88606c1abf.png)

- `ckgf_convertkit_form_page`: Permits the Role access to a Form's Settings at Forms > Edit Form > Settings > ConvertKit
![Screenshot 2022-07-18 at 12 15 09](https://user-images.githubusercontent.com/1462305/179499976-27ccf9a9-85dd-4ca6-9196-baaeee198d12.png)

- `ckgf_convertkit_uninstall`: Permits the Role access to the Plugin's uninstall routine / action at Forms > Settings > Uninstall.
![Screenshot 2022-07-18 at 12 15 15](https://user-images.githubusercontent.com/1462305/179499989-9d685f5b-d296-4938-b4e5-5498558708ae.png)

## Testing

- `CapabilitiesCest`: Adds tests to confirm that a WordPress User assigned to a Role that has a capability enabled / disabled is honored.

## Checklist

* [x] I have [written a test](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)