### PR TITLE
Tests: Apply Coding Standards

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -116,10 +116,15 @@ jobs:
         working-directory: ${{ env.PLUGIN_DIR }}
         run: composer dump-autoload
 
-      # Run WordPress Coding Standards tests.
-      - name: Run WordPress Coding Standards Tests
+      # Run Coding Standards on Tests.
+      - name: Run Coding Standards on Tests
         working-directory: ${{ env.PLUGIN_DIR }}
-        run: php vendor/bin/phpcs ./ -v -s
+        run: php vendor/bin/phpcs ./tests --standard=phpcs.tests.xml -v -s
+
+      # Run WordPress Coding Standards on Plugin.
+      - name: Run WordPress Coding Standards
+        working-directory: ${{ env.PLUGIN_DIR }}
+        run: php vendor/bin/phpcs ./ --standard=phpcs.xml -v -s
 
       # Run PHPStan for static analysis.
       - name: Run PHPStan Static Analysis

--- a/phpcs.tests.xml
+++ b/phpcs.tests.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHP_CodeSniffer" xsi:noNamespaceSchemaLocation="phpcs.xsd">
+    <description>Coding Standards for Tests</description>
+
+    <!-- Check that code meets WordPress-Extra standards. -->
+    <rule ref="WordPress-Extra">
+        <!-- Don't use yoda conditions -->
+        <exclude name="WordPress.PHP.YodaConditions" />
+
+        <!-- File and variable naming conventions in Codeception differ from WordPress -->
+        <exclude name="WordPress.NamingConventions" />
+        <exclude name="WordPress.Files.FileName" />
+
+        <!-- Class and function braces and spacing in Codeceptoin differs from WordPress -->
+        <exclude name="WordPress.WhiteSpace.ControlStructureSpacing.NoSpaceAfterOpenParenthesis" />
+        <exclude name="WordPress.WhiteSpace.ControlStructureSpacing.ExtraSpaceAfterCloseParenthesis" />
+        <exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingAfterOpen" />
+        <exclude name="WordPress.WhiteSpace.ControlStructureSpacing.NoSpaceBeforeCloseParenthesis" />
+        <exclude name="Generic.Classes.OpeningBraceSameLine.BraceOnNewLine" />
+        <exclude name="Generic.Functions.OpeningFunctionBraceKernighanRitchie.BraceOnNewLine" />
+        <exclude name="PEAR.Functions.FunctionCallSignature.SpaceBeforeOpenBracket" />
+        <exclude name="PEAR.Functions.FunctionCallSignature.SpaceAfterOpenBracket" />
+        <exclude name="PEAR.Functions.FunctionCallSignature.SpaceBeforeCloseBracket" />
+
+        <!-- _before() and _passed() must use underscores in Codeception -->
+        <exclude name="PSR2.Methods.MethodDeclaration.Underscore" />
+
+        <!-- Permit [] instead of array() -->
+        <exclude name="Generic.Arrays.DisallowShortArraySyntax.Found" />
+        
+        <!-- We might use some datetime functions for tests -->
+        <exclude name="WordPress.DateTime.RestrictedFunctions" />
+
+        <!-- Handles false positives where Coding Standards thinks we did something wrong when we're just checking for e.g. a stylesheet -->
+        <exclude name="WordPress.WP.EnqueuedResources" />
+        <exclude name="WordPress.PHP.DiscouragedPHPFunctions" />
+        <exclude name="WordPress.WP.CapitalPDangit.Misspelled" />
+    </rule>
+
+    <!-- Check that code is documented to WordPress Standards. -->
+    <rule ref="WordPress-Docs">
+        <!-- File document level comments are useless for tests; we know what a test suite does -->
+        <exclude name="Squiz.Commenting.FileComment.Missing" />
+    </rule>
+
+    <!-- Add in some extra rules from other standards. -->
+    <rule ref="Generic.CodeAnalysis.UnusedFunctionParameter"/>
+    <rule ref="Generic.Commenting.Todo"/>
+</ruleset>

--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -3,6 +3,7 @@
 
 /**
  * Inherited Methods
+ *
  * @method void wantToTest($text)
  * @method void wantTo($text)
  * @method void execute($callable)
@@ -15,7 +16,7 @@
  * @method void pause()
  *
  * @SuppressWarnings(PHPMD)
-*/
+ */
 class AcceptanceTester extends \Codeception\Actor
 {
 	use _generated\AcceptanceTesterActions;

--- a/tests/_support/FunctionalTester.php
+++ b/tests/_support/FunctionalTester.php
@@ -3,6 +3,7 @@
 
 /**
  * Inherited Methods
+ *
  * @method void wantToTest($text)
  * @method void wantTo($text)
  * @method void execute($callable)
@@ -15,7 +16,7 @@
  * @method void pause()
  *
  * @SuppressWarnings(PHPMD)
-*/
+ */
 class FunctionalTester extends \Codeception\Actor
 {
 	use _generated\FunctionalTesterActions;

--- a/tests/_support/Helper/Acceptance.php
+++ b/tests/_support/Helper/Acceptance.php
@@ -1,15 +1,16 @@
 <?php
 namespace Helper;
 
-// For readibility and portability of helpers between Plugins,
-// Acceptance helpers which work with specific WordPress / API
-// functionality (such as Gutenberg, Plugin config or the API)
-// can be found in the `Acceptance` subfolder.
-// If adding a new Helper to the `Acceptance` subfolder, remember
-// to load it through the `acceptance.suite.yml` file.
-
-// Helper functions placed here should be very generic
-
+/**
+ * For readibility and portability of helpers between Plugins,
+ * Acceptance helpers which work with specific WordPress / API
+ * functionality (such as Gutenberg, Plugin config or the API)
+ * can be found in the `Acceptance` subfolder.
+ * If adding a new Helper to the `Acceptance` subfolder, remember
+ * to load it through the `acceptance.suite.yml` file.
+ *
+ * Helper functions placed here should be very generic.
+ */
 class Acceptance extends \Codeception\Module
 {
 	/**

--- a/tests/_support/Helper/Acceptance/ConvertKitAPI.php
+++ b/tests/_support/Helper/Acceptance/ConvertKitAPI.php
@@ -1,17 +1,19 @@
 <?php
 namespace Helper\Acceptance;
 
-// Define any custom actions related to the ConvertKit API that
-// would be used across multiple tests.
-// These are then available in $I->{yourFunctionName}
-
+/**
+ * Helper methods and actions related to the ConvertKit API,
+ * which are then available using $I->{yourFunctionName}.
+ *
+ * @since   1.9.6
+ */
 class ConvertKitAPI extends \Codeception\Module
 {
 	/**
 	 * Check the given email address exists as a subscriber.
 	 *
-	 * @param   AcceptanceTester $I             AcceptanceTester
-	 * @param   string           $emailAddress   Email Address
+	 * @param   AcceptanceTester $I             AcceptanceTester.
+	 * @param   string           $emailAddress   Email Address.
 	 */
 	public function apiCheckSubscriberExists($I, $emailAddress)
 	{
@@ -32,8 +34,8 @@ class ConvertKitAPI extends \Codeception\Module
 	/**
 	 * Check the given email address does not exists as a subscriber.
 	 *
-	 * @param   AcceptanceTester $I             AcceptanceTester
-	 * @param   string           $emailAddress   Email Address
+	 * @param   AcceptanceTester $I             AcceptanceTester.
+	 * @param   string           $emailAddress   Email Address.
 	 */
 	public function apiCheckSubscriberDoesNotExist($I, $emailAddress)
 	{
@@ -54,7 +56,7 @@ class ConvertKitAPI extends \Codeception\Module
 	 * Unsubscribes the given email address. Useful for clearing the API
 	 * between tests.
 	 *
-	 * @param   string $emailAddress   Email Address
+	 * @param   string $emailAddress   Email Address.
 	 */
 	public function apiUnsubscribe($emailAddress)
 	{
@@ -73,9 +75,9 @@ class ConvertKitAPI extends \Codeception\Module
 	 *
 	 * @since   1.2.1
 	 *
-	 * @param   $I
-	 * @param   $emailAddress   Email Address.
-	 * @param   $tagID          Tag ID.
+	 * @param   AcceptanceTester $I              AcceptanceTester.
+	 * @param   string           $emailAddress   Email Address.
+	 * @param   int              $tagID          Tag ID.
 	 */
 	public function apiCheckSubscriberHasTag($I, $emailAddress, $tagID)
 	{
@@ -84,7 +86,7 @@ class ConvertKitAPI extends \Codeception\Module
 
 		$subscriberTagged = false;
 		foreach ($subscribers as $subscriber) {
-			if ($subscriber['subscriber']['email_address'] == $emailAddress) {
+			if ($subscriber['subscriber']['email_address'] === $emailAddress) {
 				$subscriberTagged = true;
 				break;
 			}
@@ -99,9 +101,9 @@ class ConvertKitAPI extends \Codeception\Module
 	 *
 	 * @since   1.2.1
 	 *
-	 * @param   $I
-	 * @param   $emailAddress   Email Address.
-	 * @param   $tagID          Tag ID.
+	 * @param   AcceptanceTester $I              AcceptanceTester.
+	 * @param   string           $emailAddress   Email Address.
+	 * @param   int              $tagID          Tag ID.
 	 */
 	public function apiCheckSubscriberDoesNotHaveTag($I, $emailAddress, $tagID)
 	{
@@ -110,7 +112,7 @@ class ConvertKitAPI extends \Codeception\Module
 
 		$subscriberTagged = false;
 		foreach ($subscribers as $subscriber) {
-			if ($subscriber['subscriber']['email_address'] == $emailAddress) {
+			if ($subscriber['subscriber']['email_address'] === $emailAddress) {
 				$subscriberTagged = true;
 				break;
 			}
@@ -133,7 +135,7 @@ class ConvertKitAPI extends \Codeception\Module
 		$data        = $subscribers['subscriptions'];
 		$totalPages  = $subscribers['total_pages'];
 
-		if ($totalPages == 1) {
+		if ($totalPages === 1) {
 			return $data;
 		}
 
@@ -157,9 +159,9 @@ class ConvertKitAPI extends \Codeception\Module
 	 * Sends a request to the ConvertKit API, typically used to read an endpoint to confirm
 	 * that data in an Acceptance Test was added/edited/deleted successfully.
 	 *
-	 * @param   string $endpoint   Endpoint
-	 * @param   string $method     Method (GET|POST|PUT)
-	 * @param   array  $params     Endpoint Parameters
+	 * @param   string $endpoint   Endpoint.
+	 * @param   string $method     Method (GET|POST|PUT).
+	 * @param   array  $params     Endpoint Parameters.
 	 */
 	public function apiRequest($endpoint, $method = 'GET', $params = array())
 	{

--- a/tests/_support/Helper/Acceptance/ConvertKitAPI.php
+++ b/tests/_support/Helper/Acceptance/ConvertKitAPI.php
@@ -9,16 +9,20 @@ class ConvertKitAPI extends \Codeception\Module
 {
 	/**
 	 * Check the given email address exists as a subscriber.
-	 * 
-	 * @param 	AcceptanceTester $I 			AcceptanceTester
-	 * @param 	string 			$emailAddress 	Email Address
-	 */ 	
+	 *
+	 * @param   AcceptanceTester $I             AcceptanceTester
+	 * @param   string           $emailAddress   Email Address
+	 */
 	public function apiCheckSubscriberExists($I, $emailAddress)
 	{
 		// Run request.
-		$results = $this->apiRequest('subscribers', 'GET', [
-			'email_address' => $emailAddress,
-		]);
+		$results = $this->apiRequest(
+			'subscribers',
+			'GET',
+			[
+				'email_address' => $emailAddress,
+			]
+		);
 
 		// Check at least one subscriber was returned and it matches the email address.
 		$I->assertGreaterThan(0, $results['total_subscribers']);
@@ -27,16 +31,20 @@ class ConvertKitAPI extends \Codeception\Module
 
 	/**
 	 * Check the given email address does not exists as a subscriber.
-	 * 
-	 * @param 	AcceptanceTester $I 			AcceptanceTester
-	 * @param 	string 			$emailAddress 	Email Address
-	 */ 	
+	 *
+	 * @param   AcceptanceTester $I             AcceptanceTester
+	 * @param   string           $emailAddress   Email Address
+	 */
 	public function apiCheckSubscriberDoesNotExist($I, $emailAddress)
 	{
 		// Run request.
-		$results = $this->apiRequest('subscribers', 'GET', [
-			'email_address' => $emailAddress,
-		]);
+		$results = $this->apiRequest(
+			'subscribers',
+			'GET',
+			[
+				'email_address' => $emailAddress,
+			]
+		);
 
 		// Check no subscribers are returned by this request.
 		$I->assertEquals(0, $results['total_subscribers']);
@@ -45,25 +53,29 @@ class ConvertKitAPI extends \Codeception\Module
 	/**
 	 * Unsubscribes the given email address. Useful for clearing the API
 	 * between tests.
-	 * 
-	 * @param 	string 			$emailAddress 	Email Address
-	 */ 	
+	 *
+	 * @param   string $emailAddress   Email Address
+	 */
 	public function apiUnsubscribe($emailAddress)
 	{
 		// Run request.
-		$this->apiRequest('unsubscribe', 'PUT', [
-			'email' => $emailAddress,
-		]);
+		$this->apiRequest(
+			'unsubscribe',
+			'PUT',
+			[
+				'email' => $emailAddress,
+			]
+		);
 	}
 
-/**
+	/**
 	 * Checks if the given email address has the given tag.
-	 * 
-	 * @since 	1.2.1
-	 * 
-	 * @param 	$I
-	 * @param 	$emailAddress 	Email Address.
-	 * @param 	$tagID 			Tag ID.
+	 *
+	 * @since   1.2.1
+	 *
+	 * @param   $I
+	 * @param   $emailAddress   Email Address.
+	 * @param   $tagID          Tag ID.
 	 */
 	public function apiCheckSubscriberHasTag($I, $emailAddress, $tagID)
 	{
@@ -84,18 +96,18 @@ class ConvertKitAPI extends \Codeception\Module
 
 	/**
 	 * Checks if the given email address does not have the given tag.
-	 * 
-	 * @since 	1.2.1
-	 * 
-	 * @param 	$I
-	 * @param 	$emailAddress 	Email Address.
-	 * @param 	$tagID 			Tag ID.
+	 *
+	 * @since   1.2.1
+	 *
+	 * @param   $I
+	 * @param   $emailAddress   Email Address.
+	 * @param   $tagID          Tag ID.
 	 */
 	public function apiCheckSubscriberDoesNotHaveTag($I, $emailAddress, $tagID)
 	{
 		// Get Subscribers.
 		$subscribers = $this->apiGetSubscribersByTagID($tagID);
-			
+
 		$subscriberTagged = false;
 		foreach ($subscribers as $subscriber) {
 			if ($subscriber['subscriber']['email_address'] == $emailAddress) {
@@ -110,16 +122,16 @@ class ConvertKitAPI extends \Codeception\Module
 
 	/**
 	 * Returns all subscribers to the given Tag ID from the API.
-	 * 
-	 * @param 	int 	$tagID 	Tag ID.
-	 * @return 	array
+	 *
+	 * @param   int $tagID  Tag ID.
+	 * @return  array
 	 */
 	public function apiGetSubscribersByTagID($tagID)
 	{
 		// Get first page of subscribers.
-		$subscribers = $this->apiRequest('tags/'.$tagID.'/subscriptions', 'GET');
-		$data = $subscribers['subscriptions'];
-		$totalPages = $subscribers['total_pages'];
+		$subscribers = $this->apiRequest('tags/' . $tagID . '/subscriptions', 'GET');
+		$data        = $subscribers['subscriptions'];
+		$totalPages  = $subscribers['total_pages'];
 
 		if ($totalPages == 1) {
 			return $data;
@@ -127,9 +139,13 @@ class ConvertKitAPI extends \Codeception\Module
 
 		// Get additional pages of purchases.
 		for ($page = 2; $page <= $totalPages; $page++) {
-			$subscribers = $this->apiRequest('tags/'.$tagID.'/subscriptions', 'GET', [
-				'page' => $page,
-			]);
+			$subscribers = $this->apiRequest(
+				'tags/' . $tagID . '/subscriptions',
+				'GET',
+				[
+					'page' => $page,
+				]
+			);
 
 			$data = array_merge($data, $subscribers['subscriptions']);
 		}
@@ -140,32 +156,39 @@ class ConvertKitAPI extends \Codeception\Module
 	/**
 	 * Sends a request to the ConvertKit API, typically used to read an endpoint to confirm
 	 * that data in an Acceptance Test was added/edited/deleted successfully.
-	 * 
-	 * @param 	string 	$endpoint 	Endpoint
-	 * @param 	string 	$method 	Method (GET|POST|PUT)
-	 * @param 	array 	$params 	Endpoint Parameters
+	 *
+	 * @param   string $endpoint   Endpoint
+	 * @param   string $method     Method (GET|POST|PUT)
+	 * @param   array  $params     Endpoint Parameters
 	 */
 	public function apiRequest($endpoint, $method = 'GET', $params = array())
 	{
 		// Build query parameters.
-		$params = array_merge($params, [
-			'api_key' => $_ENV['CONVERTKIT_API_KEY'],
-			'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
-		]);
+		$params = array_merge(
+			$params,
+			[
+				'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
+				'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
+			]
+		);
 
 		// Send request.
 		try {
 			$client = new \GuzzleHttp\Client();
-			$result = $client->request($method, 'https://api.convertkit.com/v3/' . $endpoint . '?' . http_build_query($params), [
-				'headers' => [
-					'Accept-Encoding' => 'gzip',
-					'timeout'         => 5,
-				],
-			]);
+			$result = $client->request(
+				$method,
+				'https://api.convertkit.com/v3/' . $endpoint . '?' . http_build_query($params),
+				[
+					'headers' => [
+						'Accept-Encoding' => 'gzip',
+						'timeout'         => 5,
+					],
+				]
+			);
 
 			// Return JSON decoded response.
 			return json_decode($result->getBody()->getContents(), true);
-		} catch(\GuzzleHttp\Exception\ClientException $e) {
+		} catch (\GuzzleHttp\Exception\ClientException $e) {
 			return [];
 		}
 	}

--- a/tests/_support/Helper/Acceptance/Email.php
+++ b/tests/_support/Helper/Acceptance/Email.php
@@ -10,16 +10,16 @@ class Email extends \Codeception\Module
 	/**
 	 * Generates a unique email address for use in a test, comprising of a prefix,
 	 * date + time and PHP version number.
-	 * 
+	 *
 	 * This ensures that if tests are run in parallel, the same email address
 	 * isn't used for two tests across parallel testing runs.
-	 * 
-	 * @since 	1.9.6.7
+	 *
+	 * @since   1.9.6.7
 	 */
 	public function generateEmailAddress()
 	{
 		// Include uniqid() as there's a possibility that tests run in parallel on the same PHP version
 		// could request an email address on the same second.
-		return 'wordpress-'.uniqid().'-' . date( 'Y-m-d-H-i-s' ) . '-php-' . PHP_VERSION_ID . '@convertkit.com';
+		return 'wordpress-' . uniqid() . '-' . date( 'Y-m-d-H-i-s' ) . '-php-' . PHP_VERSION_ID . '@convertkit.com';
 	}
 }

--- a/tests/_support/Helper/Acceptance/Email.php
+++ b/tests/_support/Helper/Acceptance/Email.php
@@ -1,10 +1,12 @@
 <?php
 namespace Helper\Acceptance;
 
-// Define any custom actions related to Select2 interaction that
-// would be used across multiple tests.
-// These are then available in $I->{yourFunctionName}
-
+/**
+ * Helper methods and actions related to email addresses,
+ * which are then available using $I->{yourFunctionName}.
+ *
+ * @since   1.2.1
+ */
 class Email extends \Codeception\Module
 {
 	/**
@@ -14,12 +16,12 @@ class Email extends \Codeception\Module
 	 * This ensures that if tests are run in parallel, the same email address
 	 * isn't used for two tests across parallel testing runs.
 	 *
-	 * @since   1.9.6.7
+	 * @since   1.2.1
 	 */
 	public function generateEmailAddress()
 	{
 		// Include uniqid() as there's a possibility that tests run in parallel on the same PHP version
-		// could request an email address on the same second.
+		// could request an email address on the same second..
 		return 'wordpress-' . uniqid() . '-' . date( 'Y-m-d-H-i-s' ) . '-php-' . PHP_VERSION_ID . '@convertkit.com';
 	}
 }

--- a/tests/_support/Helper/Acceptance/GravityForms.php
+++ b/tests/_support/Helper/Acceptance/GravityForms.php
@@ -1,10 +1,12 @@
 <?php
 namespace Helper\Acceptance;
 
-// Define any custom actions related to the Gravity Forms Plugin that
-// would be used across multiple tests.
-// These are then available in $I->{yourFunctionName}
-
+/**
+ * Helper methods and actions related to the Gravity Forms Plugin,
+ * which are then available using $I->{yourFunctionName}.
+ *
+ * @since   1.2.1
+ */
 class GravityForms extends \Codeception\Module
 {
 	/**
@@ -12,7 +14,7 @@ class GravityForms extends \Codeception\Module
 	 *
 	 * @since   1.2.1
 	 *
-	 * @param   AcceptanceTester $I                  AcceptanceTester.
+	 * @param   AcceptanceTester $I     AcceptanceTester.
 	 * @return  int                     Form ID.
 	 */
 	public function createGravityFormsForm($I)
@@ -191,7 +193,7 @@ class GravityForms extends \Codeception\Module
 		// Load Form's ConvertKit Feed Settings.
 		$I->amOnAdminPage('admin.php?page=gf_edit_forms&view=settings&subview=ckgf&id=' . $gravityFormID);
 
-		// Deactivate the Feed
+		// Deactivate the Feed.
 		$I->click('table.feeds tbody tr:nth-child(' . $gravityFormFeedID . ') th.manage-column button.gform-status--active');
 	}
 
@@ -222,6 +224,8 @@ class GravityForms extends \Codeception\Module
 	 * Checks that a success or error note was added by the Plugin to the most recent Gravity Forms Entry.
 	 *
 	 * @since   1.2.1
+	 *
+	 * @param   AcceptanceTester $I AcceptanceTester.
 	 */
 	public function checkGravityFormsNotesExist($I)
 	{
@@ -238,6 +242,8 @@ class GravityForms extends \Codeception\Module
 	 * Checks that a success note was added by the Plugin to the most recent Gravity Forms Entry.
 	 *
 	 * @since   1.2.1
+	 *
+	 * @param   AcceptanceTester $I AcceptanceTester.
 	 */
 	public function checkGravityFormsSuccessNotesExist($I)
 	{
@@ -254,6 +260,8 @@ class GravityForms extends \Codeception\Module
 	 * Checks that an error note was added by the Plugin to the most recent Gravity Forms Entry.
 	 *
 	 * @since   1.2.1
+	 *
+	 * @param   AcceptanceTester $I AcceptanceTester.
 	 */
 	public function checkGravityFormsErrorNotesExist($I)
 	{
@@ -270,6 +278,8 @@ class GravityForms extends \Codeception\Module
 	 * Checks that no Notes were added by the Plugin to the most recent Gravity Forms Entry.
 	 *
 	 * @since   1.2.1
+	 *
+	 * @param   AcceptanceTester $I AcceptanceTester.
 	 */
 	public function checkGravityFormsNotesDoNotExist($I)
 	{
@@ -286,10 +296,10 @@ class GravityForms extends \Codeception\Module
 	 *
 	 * @since   1.2.5
 	 *
-	 * @param   AcceptanceTester $I          Tester
-	 * @param   bool             $settings   Role has access to Plugin's Settings
-	 * @param   bool             $form       Role has access to Plugin's Form Settings
-	 * @param   bool             $uninstall  Role has access to Plugin's Uninstallation action
+	 * @param   AcceptanceTester $I          Tester.
+	 * @param   bool             $settings   Role has access to Plugin's Settings.
+	 * @param   bool             $form       Role has access to Plugin's Form Settings.
+	 * @param   bool             $uninstall  Role has access to Plugin's Uninstallation action.
 	 */
 	public function createGravityFormsRole($I, $settings = true, $form = true, $uninstall = true)
 	{

--- a/tests/_support/Helper/Acceptance/GravityForms.php
+++ b/tests/_support/Helper/Acceptance/GravityForms.php
@@ -9,11 +9,11 @@ class GravityForms extends \Codeception\Module
 {
 	/**
 	 * Creates a Gravity Forms Form.
-	 * 
-	 * @since 	1.2.1
-	 * 
-	 * @param 	AcceptanceTester 	$I  				AcceptanceTester.
-	 * @return 	int 					Form ID.
+	 *
+	 * @since   1.2.1
+	 *
+	 * @param   AcceptanceTester $I                  AcceptanceTester.
+	 * @return  int                     Form ID.
 	 */
 	public function createGravityFormsForm($I)
 	{
@@ -21,7 +21,7 @@ class GravityForms extends \Codeception\Module
 		$I->amOnAdminPage('admin.php?page=gf_new_form');
 
 		// Define Title.
-		$I->fillField('#new_form_title', 'ConvertKit Form Test: '.date('Y-m-d H:i:s').' on PHP '.PHP_VERSION_ID);
+		$I->fillField('#new_form_title', 'ConvertKit Form Test: ' . date('Y-m-d H:i:s') . ' on PHP ' . PHP_VERSION_ID);
 
 		// Click Create Form button.
 		$I->click('Create Form');
@@ -65,11 +65,11 @@ class GravityForms extends \Codeception\Module
 
 		// Show Values.
 		$I->click('#choices-ui-flyout .gform-flyout__body label[for=field_choice_values_enabled]');
-		
+
 		// Define Tags.
 		$I->fillField('#select_choice_text_0', 'Select Tag');
 		$I->fillField('#select_choice_value_0', '');
-		
+
 		$I->fillField('#select_choice_text_1', 'Tag Label 1');
 		$I->fillField('#select_choice_value_1', $_ENV['CONVERTKIT_API_ADDITIONAL_TAG_NAME']);
 
@@ -78,7 +78,7 @@ class GravityForms extends \Codeception\Module
 
 		// Close Choices flyout.
 		$I->click('#choices-ui-flyout .gform-flyout__close');
-	
+
 		// Update.
 		$I->click('button.update-form');
 
@@ -88,15 +88,15 @@ class GravityForms extends \Codeception\Module
 
 	/**
 	 * Creates a Gravity Forms ConvertKit Feed (a feed sends form entries to ConvertKit) for the given Gravity Form.
-	 * 
-	 * @since 	1.2.1
-	 * 
-	 * @param 	AcceptanceTester 	$I 				AcceptanceTester.
-	 * @param 	int 				$gravityFormID 	Gravity Forms Form ID.
-	 * @param 	string 				$formName 		ConvertKit Form Name.
-	 * @param 	mixed 				$tagName 		ConvertKit Tag Name.
-	 * @param 	bool				$mapTagField 	Whether to map the Tag field.
-	 * @param 	mixed 				$emailFieldName Gravity Forms Field Name to map to ConvertKit Email Address.
+	 *
+	 * @since   1.2.1
+	 *
+	 * @param   AcceptanceTester $I              AcceptanceTester.
+	 * @param   int              $gravityFormID  Gravity Forms Form ID.
+	 * @param   string           $formName       ConvertKit Form Name.
+	 * @param   mixed            $tagName        ConvertKit Tag Name.
+	 * @param   bool             $mapTagField    Whether to map the Tag field.
+	 * @param   mixed            $emailFieldName Gravity Forms Field Name to map to ConvertKit Email Address.
 	 */
 	public function createGravityFormsFeed($I, $gravityFormID, $formName, $tagName = false, $mapTagField = false, $emailFieldName = 'Email')
 	{
@@ -134,14 +134,14 @@ class GravityForms extends \Codeception\Module
 
 	/**
 	 * Completes form fields for a Gravity Forms ConvertKit Feed Settings.
-	 * 
-	 * @since 	1.2.1
-	 * 
-	 * @param 	AcceptanceTester 	$I 				AcceptanceTester.
-	 * @param 	string 				$formName 		ConvertKit Form Name.
-	 * @param 	mixed 				$tagName 		ConvertKit Tag Name.
-	 * @param 	bool				$mapTagField 	Whether to map the Tag field.
-	 * @param 	mixed 				$emailFieldName Gravity Forms Field Name to map to ConvertKit Email Address.
+	 *
+	 * @since   1.2.1
+	 *
+	 * @param   AcceptanceTester $I              AcceptanceTester.
+	 * @param   string           $formName       ConvertKit Form Name.
+	 * @param   mixed            $tagName        ConvertKit Tag Name.
+	 * @param   bool             $mapTagField    Whether to map the Tag field.
+	 * @param   mixed            $emailFieldName Gravity Forms Field Name to map to ConvertKit Email Address.
 	 */
 	public function completeGravityFormsFeedFields($I, $formName, $tagName = false, $mapTagField = false, $emailFieldName = 'Email')
 	{
@@ -179,12 +179,12 @@ class GravityForms extends \Codeception\Module
 
 	/**
 	 * Disables the given feed for the given Gravity Form ID.
-	 * 
-	 * @since 	1.2.1
-	 * 
-	 * @param 	AcceptanceTester 	$I 					AcceptanceTester.
-	 * @param 	int 				$gravityFormID 		Gravity Forms Form ID.
-	 * @param 	int 				$gravityFormFeedID 	Gravity Forms Feed ID.
+	 *
+	 * @since   1.2.1
+	 *
+	 * @param   AcceptanceTester $I                  AcceptanceTester.
+	 * @param   int              $gravityFormID      Gravity Forms Form ID.
+	 * @param   int              $gravityFormFeedID  Gravity Forms Feed ID.
 	 */
 	public function disableGravityFormsFeed($I, $gravityFormID, $gravityFormFeedID = 1)
 	{
@@ -198,28 +198,30 @@ class GravityForms extends \Codeception\Module
 	/**
 	 * Creates a WordPress Page with the Gravity Form shortcode as the content
 	 * to render the Gravity Form.
-	 * 
-	 * @since 	1.2.1
-	 * 
-	 * @param 	AcceptanceTester 	$I 				AcceptanceTester.
-	 * @param 	int 				$gravityFormID 	Gravity Forms Form ID.
-	 * @return 	int 								Page ID
+	 *
+	 * @since   1.2.1
+	 *
+	 * @param   AcceptanceTester $I              AcceptanceTester.
+	 * @param   int              $gravityFormID  Gravity Forms Form ID.
+	 * @return  int                                 Page ID
 	 */
 	public function createPageWithGravityFormShortcode($I, $gravityFormID)
 	{
-		return $I->havePostInDatabase([
-			'post_type'		=> 'page',
-			'post_status'	=> 'publish',
-			'post_name' 	=> 'gravity-form-' . $gravityFormID,
-			'post_title'	=> 'Gravity Form #' . $gravityFormID,
-			'post_content'	=> '[gravityform id="' . $gravityFormID . '" title="false" description="false"]',
-		]);
+		return $I->havePostInDatabase(
+			[
+				'post_type'    => 'page',
+				'post_status'  => 'publish',
+				'post_name'    => 'gravity-form-' . $gravityFormID,
+				'post_title'   => 'Gravity Form #' . $gravityFormID,
+				'post_content' => '[gravityform id="' . $gravityFormID . '" title="false" description="false"]',
+			]
+		);
 	}
 
 	/**
 	 * Checks that a success or error note was added by the Plugin to the most recent Gravity Forms Entry.
-	 * 
-	 * @since 	1.2.1
+	 *
+	 * @since   1.2.1
 	 */
 	public function checkGravityFormsNotesExist($I)
 	{
@@ -234,8 +236,8 @@ class GravityForms extends \Codeception\Module
 
 	/**
 	 * Checks that a success note was added by the Plugin to the most recent Gravity Forms Entry.
-	 * 
-	 * @since 	1.2.1
+	 *
+	 * @since   1.2.1
 	 */
 	public function checkGravityFormsSuccessNotesExist($I)
 	{
@@ -250,8 +252,8 @@ class GravityForms extends \Codeception\Module
 
 	/**
 	 * Checks that an error note was added by the Plugin to the most recent Gravity Forms Entry.
-	 * 
-	 * @since 	1.2.1
+	 *
+	 * @since   1.2.1
 	 */
 	public function checkGravityFormsErrorNotesExist($I)
 	{
@@ -266,8 +268,8 @@ class GravityForms extends \Codeception\Module
 
 	/**
 	 * Checks that no Notes were added by the Plugin to the most recent Gravity Forms Entry.
-	 * 
-	 * @since 	1.2.1
+	 *
+	 * @since   1.2.1
 	 */
 	public function checkGravityFormsNotesDoNotExist($I)
 	{
@@ -279,48 +281,52 @@ class GravityForms extends \Codeception\Module
 
 	/**
 	 * Creates a role called 'gravity_forms'.
-	 * 
+	 *
 	 * If the role exists, deletes it before creating.
-	 * 
-	 * @since 	1.2.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 			Tester
-	 * @param 	bool 				$settings 	Role has access to Plugin's Settings
-	 * @param 	bool 				$form 		Role has access to Plugin's Form Settings
-	 * @param 	bool 				$uninstall 	Role has access to Plugin's Uninstallation action
+	 *
+	 * @since   1.2.5
+	 *
+	 * @param   AcceptanceTester $I          Tester
+	 * @param   bool             $settings   Role has access to Plugin's Settings
+	 * @param   bool             $form       Role has access to Plugin's Form Settings
+	 * @param   bool             $uninstall  Role has access to Plugin's Uninstallation action
 	 */
 	public function createGravityFormsRole($I, $settings = true, $form = true, $uninstall = true)
 	{
 		$I->deleteRole($I, 'gravity_forms');
-		$I->addRole($I, 'gravity_forms', [
-			// General.
-			'edit_dashboard' => true,
-			'read' => true,
+		$I->addRole(
+			$I,
+			'gravity_forms',
+			[
+				// General.
+				'edit_dashboard'                => true,
+				'read'                          => true,
 
-			// Gravity Forms.
-			'gravityforms_api_settings' => true,
-			'gravityforms_create_form' => true,
-			'gravityforms_delete_entries' => true,
-			'gravityforms_delete_forms' => true,
-			'gravityforms_edit_entries' => true,
-			'gravityforms_edit_entry_notes' => true,
-			'gravityforms_edit_forms' => true,
-			'gravityforms_edit_settings' => true,
-			'gravityforms_export_entries' => true,
-			'gravityforms_logging' => true,
-			'gravityforms_preview_forms' => true,
-			'gravityforms_system_status' => true,
-			'gravityforms_uninstall' => true,
-			'gravityforms_view_addons' => true,
-			'gravityforms_view_entries' => true,
-			'gravityforms_view_entry_notes' => true,
-			'gravityforms_view_settings' => true,
-			'gravityforms_view_updates' => true,
+				// Gravity Forms.
+				'gravityforms_api_settings'     => true,
+				'gravityforms_create_form'      => true,
+				'gravityforms_delete_entries'   => true,
+				'gravityforms_delete_forms'     => true,
+				'gravityforms_edit_entries'     => true,
+				'gravityforms_edit_entry_notes' => true,
+				'gravityforms_edit_forms'       => true,
+				'gravityforms_edit_settings'    => true,
+				'gravityforms_export_entries'   => true,
+				'gravityforms_logging'          => true,
+				'gravityforms_preview_forms'    => true,
+				'gravityforms_system_status'    => true,
+				'gravityforms_uninstall'        => true,
+				'gravityforms_view_addons'      => true,
+				'gravityforms_view_entries'     => true,
+				'gravityforms_view_entry_notes' => true,
+				'gravityforms_view_settings'    => true,
+				'gravityforms_view_updates'     => true,
 
-			// Plugin.
-			'ckgf_convertkit_settings_page' => $settings,
-			'ckgf_convertkit_form_page' => $form,
-			'ckgf_convertkit_uninstall' => $uninstall,
-		]);
+				// Plugin.
+				'ckgf_convertkit_settings_page' => $settings,
+				'ckgf_convertkit_form_page'     => $form,
+				'ckgf_convertkit_uninstall'     => $uninstall,
+			]
+		);
 	}
 }

--- a/tests/_support/Helper/Acceptance/Plugin.php
+++ b/tests/_support/Helper/Acceptance/Plugin.php
@@ -1,17 +1,21 @@
 <?php
 namespace Helper\Acceptance;
 
-// Define any custom actions related to the ConvertKit Plugin that
-// would be used across multiple tests.
-// These are then available in $I->{yourFunctionName}
-
+/**
+ * Helper methods and actions related to the ConvertKit Plugin,
+ * which are then available using $I->{yourFunctionName}.
+ *
+ * @since   1.2.1
+ */
 class Plugin extends \Codeception\Module
 {
 	/**
 	 * Helper method to activate the ConvertKit Plugin, checking
 	 * it activated and no errors were output.
 	 *
-	 * @since   1.9.6
+	 * @since   1.2.1
+	 *
+	 * @param   AcceptanceTester $I AcceptanceTester.
 	 */
 	public function activateConvertKitPlugin($I)
 	{
@@ -22,7 +26,9 @@ class Plugin extends \Codeception\Module
 	 * Helper method to deactivate the ConvertKit Plugin, checking
 	 * it activated and no errors were output.
 	 *
-	 * @since   1.9.6
+	 * @since   1.2.1
+	 *
+	 * @param   AcceptanceTester $I AcceptanceTester.
 	 */
 	public function deactivateConvertKitPlugin($I)
 	{
@@ -76,6 +82,8 @@ class Plugin extends \Codeception\Module
 	 * Helper method to reset the ConvertKit Plugin settings, as if it's a clean installation.
 	 *
 	 * @since   1.2.2
+	 *
+	 * @param   AcceptanceTester $I AcceptanceTester.
 	 */
 	public function resetConvertKitPlugin($I)
 	{

--- a/tests/_support/Helper/Acceptance/Plugin.php
+++ b/tests/_support/Helper/Acceptance/Plugin.php
@@ -10,8 +10,8 @@ class Plugin extends \Codeception\Module
 	/**
 	 * Helper method to activate the ConvertKit Plugin, checking
 	 * it activated and no errors were output.
-	 * 
-	 * @since 	1.9.6
+	 *
+	 * @since   1.9.6
 	 */
 	public function activateConvertKitPlugin($I)
 	{
@@ -21,8 +21,8 @@ class Plugin extends \Codeception\Module
 	/**
 	 * Helper method to deactivate the ConvertKit Plugin, checking
 	 * it activated and no errors were output.
-	 * 
-	 * @since 	1.9.6
+	 *
+	 * @since   1.9.6
 	 */
 	public function deactivateConvertKitPlugin($I)
 	{
@@ -31,10 +31,10 @@ class Plugin extends \Codeception\Module
 
 	/**
 	 * Helper method to setup the Plugin's API Key and Secret, and enable the integration.
-	 * 
-	 * @since 	1.2.1
-	 * 
-	 * @param 	AcceptanceTester 	$I 	AcceptanceTester.
+	 *
+	 * @since   1.2.1
+	 *
+	 * @param   AcceptanceTester $I  AcceptanceTester.
 	 */
 	public function setupConvertKitPlugin($I)
 	{
@@ -43,7 +43,7 @@ class Plugin extends \Codeception\Module
 
 		// Complete API Fields.
 		$I->fillField('_gform_setting_api_key', $_ENV['CONVERTKIT_API_KEY']);
-		
+
 		// Click the Save Settings button.
 		$I->click('#gform-settings-save');
 
@@ -59,10 +59,10 @@ class Plugin extends \Codeception\Module
 
 	/**
 	 * Helper method to load the Gravity Forms > Settings > ConvertKit screen.
-	 * 
-	 * @since 	1.2.1
-	 * 
-	 * @param 	AcceptanceTester 	$I 	AcceptanceTester.
+	 *
+	 * @since   1.2.1
+	 *
+	 * @param   AcceptanceTester $I  AcceptanceTester.
 	 */
 	public function loadConvertKitSettingsScreen($I)
 	{
@@ -74,8 +74,8 @@ class Plugin extends \Codeception\Module
 
 	/**
 	 * Helper method to reset the ConvertKit Plugin settings, as if it's a clean installation.
-	 * 
-	 * @since 	1.2.2
+	 *
+	 * @since   1.2.2
 	 */
 	public function resetConvertKitPlugin($I)
 	{

--- a/tests/_support/Helper/Acceptance/Roles.php
+++ b/tests/_support/Helper/Acceptance/Roles.php
@@ -1,10 +1,12 @@
 <?php
 namespace Helper\Acceptance;
 
-// Define any custom actions related to the ConvertKit Plugin that
-// would be used across multiple tests.
-// These are then available in $I->{yourFunctionName}
-
+/**
+ * Helper methods and actions related to WordPress Roles,
+ * which are then available using $I->{yourFunctionName}.
+ *
+ * @since   1.2.1
+ */
 class Roles extends \Codeception\Module
 {
 	/**
@@ -12,9 +14,9 @@ class Roles extends \Codeception\Module
 	 *
 	 * @since   1.2.5
 	 *
-	 * @param   AcceptanceTester $I              Tester
-	 * @param   string           $name           Programmatic name of Role
-	 * @param   array            $capabilities   Array of capabilites for the Role
+	 * @param   AcceptanceTester $I              Tester.
+	 * @param   string           $name           Programmatic name of Role.
+	 * @param   array            $capabilities   Array of capabilites for the Role.
 	 */
 	public function addRole($I, $name, $capabilities)
 	{
@@ -31,8 +33,8 @@ class Roles extends \Codeception\Module
 	 *
 	 * @since   1.2.5
 	 *
-	 * @param   AcceptanceTester $I              Tester
-	 * @param   string           $name           Programmatic name of Role
+	 * @param   AcceptanceTester $I              Tester.
+	 * @param   string           $name           Programmatic name of Role.
 	 */
 	public function deleteRole($I, $name)
 	{

--- a/tests/_support/Helper/Acceptance/Roles.php
+++ b/tests/_support/Helper/Acceptance/Roles.php
@@ -9,18 +9,18 @@ class Roles extends \Codeception\Module
 {
 	/**
 	 * Helper method add a role to WordPress.
-	 * 
-	 * @since 	1.2.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 				Tester
-	 * @param 	string 				$name 			Programmatic name of Role
-	 * @param 	array 				$capabilities 	Array of capabilites for the Role
+	 *
+	 * @since   1.2.5
+	 *
+	 * @param   AcceptanceTester $I              Tester
+	 * @param   string           $name           Programmatic name of Role
+	 * @param   array            $capabilities   Array of capabilites for the Role
 	 */
 	public function addRole($I, $name, $capabilities)
 	{
-		$roles = $I->grabOptionFromDatabase('wp_user_roles');
-		$roles[$name] = [
-			'name' => $name,
+		$roles          = $I->grabOptionFromDatabase('wp_user_roles');
+		$roles[ $name ] = [
+			'name'         => $name,
 			'capabilities' => $capabilities,
 		];
 		$I->haveOptionInDatabase('wp_user_roles', $roles);
@@ -28,16 +28,16 @@ class Roles extends \Codeception\Module
 
 	/**
 	 * Helper method delete a role from WordPress.
-	 * 
-	 * @since 	1.2.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 				Tester
-	 * @param 	string 				$name 			Programmatic name of Role
+	 *
+	 * @since   1.2.5
+	 *
+	 * @param   AcceptanceTester $I              Tester
+	 * @param   string           $name           Programmatic name of Role
 	 */
 	public function deleteRole($I, $name)
 	{
 		$roles = $I->grabOptionFromDatabase('wp_user_roles');
-		unset($roles[$name]);
+		unset($roles[ $name ]);
 		$I->haveOptionInDatabase('wp_user_roles', $roles);
 	}
 }

--- a/tests/_support/Helper/Acceptance/ThirdPartyPlugin.php
+++ b/tests/_support/Helper/Acceptance/ThirdPartyPlugin.php
@@ -1,10 +1,12 @@
 <?php
 namespace Helper\Acceptance;
 
-// Define any custom actions related to third party Plugins that
-// would be used across multiple tests.
-// These are then available in $I->{yourFunctionName}
-
+/**
+ * Helper methods and actions related to third party Plugins,
+ * which are then available using $I->{yourFunctionName}.
+ *
+ * @since   1.9.6
+ */
 class ThirdPartyPlugin extends \Codeception\Module
 {
 	/**
@@ -13,11 +15,12 @@ class ThirdPartyPlugin extends \Codeception\Module
 	 *
 	 * @since   1.9.6.7
 	 *
-	 * @param   string $name   Plugin Slug.
+	 * @param   AcceptanceTester $I     AcceptanceTester.
+	 * @param   string           $name  Plugin Slug.
 	 */
 	public function activateThirdPartyPlugin($I, $name)
 	{
-		// Login as the Administrator
+		// Login as the Administrator.
 		$I->loginAsAdmin();
 
 		// Go to the Plugins screen in the WordPress Administration interface.
@@ -25,6 +28,10 @@ class ThirdPartyPlugin extends \Codeception\Module
 
 		// Activate the Plugin.
 		$I->activatePlugin($name);
+
+		// Go to the Plugins screen again; this prevents any Plugin that loads a wizard-style screen from
+		// causing seePluginActivated() to fail.
+		$I->amOnPluginsPage();
 
 		// Some Plugins have a different slug when activated.
 		switch ($name) {
@@ -47,28 +54,31 @@ class ThirdPartyPlugin extends \Codeception\Module
 	 *
 	 * @since   1.9.6.7
 	 *
-	 * @param   string $name   Plugin Slug.
+	 * @param   AcceptanceTester $I      Acceptance Tester.
+	 * @param   string           $name   Plugin Slug.
 	 */
 	public function deactivateThirdPartyPlugin($I, $name)
 	{
-		// Login as the Administrator
+		// Login as the Administrator.
 		$I->loginAsAdmin();
 
 		// Go to the Plugins screen in the WordPress Administration interface.
 		$I->amOnPluginsPage();
 
-		// Some Plugins have a different slug when activated/deactivated.
+		// Deactivate the Plugin.
+		// Some Plugins have a different slug when activated.
 		switch ($name) {
 			case 'gravity-forms':
 				$I->deactivatePlugin('gravityforms');
-				$I->seePluginDeactivated('gravity-forms');
 				break;
 
 			default:
 				$I->deactivatePlugin($name);
-				$I->seePluginDeactivated($name);
 				break;
 		}
+
+		// Check that the Plugin deactivated successfully.
+		$I->seePluginDeactivated($name);
 
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);

--- a/tests/_support/Helper/Acceptance/ThirdPartyPlugin.php
+++ b/tests/_support/Helper/Acceptance/ThirdPartyPlugin.php
@@ -10,10 +10,10 @@ class ThirdPartyPlugin extends \Codeception\Module
 	/**
 	 * Helper method to activate a third party Plugin, checking
 	 * it activated and no errors were output.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	string 	$name 	Plugin Slug.
+	 *
+	 * @since   1.9.6.7
+	 *
+	 * @param   string $name   Plugin Slug.
 	 */
 	public function activateThirdPartyPlugin($I, $name)
 	{
@@ -27,7 +27,7 @@ class ThirdPartyPlugin extends \Codeception\Module
 		$I->activatePlugin($name);
 
 		// Some Plugins have a different slug when activated.
-		switch($name) {
+		switch ($name) {
 			case 'gravity-forms':
 				$I->seePluginActivated('gravityforms');
 				break;
@@ -44,10 +44,10 @@ class ThirdPartyPlugin extends \Codeception\Module
 	/**
 	 * Helper method to activate a third party Plugin, checking
 	 * it activated and no errors were output.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	string 	$name 	Plugin Slug.
+	 *
+	 * @since   1.9.6.7
+	 *
+	 * @param   string $name   Plugin Slug.
 	 */
 	public function deactivateThirdPartyPlugin($I, $name)
 	{
@@ -58,7 +58,7 @@ class ThirdPartyPlugin extends \Codeception\Module
 		$I->amOnPluginsPage();
 
 		// Some Plugins have a different slug when activated/deactivated.
-		switch($name) {
+		switch ($name) {
 			case 'gravity-forms':
 				$I->deactivatePlugin('gravityforms');
 				$I->seePluginDeactivated('gravity-forms');

--- a/tests/_support/Helper/Acceptance/Xdebug.php
+++ b/tests/_support/Helper/Acceptance/Xdebug.php
@@ -9,8 +9,8 @@ class Xdebug extends \Codeception\Module
 {
 	/**
 	 * Helper method to assert that there are non PHP errors, warnings or notices output
-	 * 
-	 * @since 	1.9.6
+	 *
+	 * @since   1.9.6
 	 */
 	public function checkNoWarningsAndNoticesOnScreen($I)
 	{

--- a/tests/_support/Helper/Acceptance/Xdebug.php
+++ b/tests/_support/Helper/Acceptance/Xdebug.php
@@ -1,16 +1,20 @@
 <?php
 namespace Helper\Acceptance;
 
-// Define any custom actions related to PHP's Xdebug that
-// would be used across multiple tests.
-// These are then available in $I->{yourFunctionName}
-
+/**
+ * Helper methods and actions related to PHP's Xdebug,
+ * which are then available using $I->{yourFunctionName}.
+ *
+ * @since   1.2.2
+ */
 class Xdebug extends \Codeception\Module
 {
 	/**
 	 * Helper method to assert that there are non PHP errors, warnings or notices output
 	 *
-	 * @since   1.9.6
+	 * @since   1.2.2
+	 *
+	 * @param   AcceptanceTester $I Acceptance Tester.
 	 */
 	public function checkNoWarningsAndNoticesOnScreen($I)
 	{

--- a/tests/_support/Helper/Functional.php
+++ b/tests/_support/Helper/Functional.php
@@ -1,9 +1,10 @@
 <?php
 namespace Helper;
 
-// here you can define custom actions
-// all public methods declared in helper class will be available in $I
-
+/**
+ * Here you can define custom actions
+ * All public methods declared in helper class will be available in $I
+ */
 class Functional extends \Codeception\Module
 {
 

--- a/tests/_support/Helper/Unit.php
+++ b/tests/_support/Helper/Unit.php
@@ -1,9 +1,10 @@
 <?php
 namespace Helper;
 
-// here you can define custom actions
-// all public methods declared in helper class will be available in $I
-
+/**
+ * Here you can define custom actions
+ * All public methods declared in helper class will be available in $I
+ */
 class Unit extends \Codeception\Module
 {
 

--- a/tests/_support/Helper/Wpunit.php
+++ b/tests/_support/Helper/Wpunit.php
@@ -1,9 +1,10 @@
 <?php
 namespace Helper;
 
-// here you can define custom actions
-// all public methods declared in helper class will be available in $I
-
+/**
+ * Here you can define custom actions
+ * All public methods declared in helper class will be available in $I
+ */
 class Wpunit extends \Codeception\Module
 {
 

--- a/tests/_support/UnitTester.php
+++ b/tests/_support/UnitTester.php
@@ -3,6 +3,7 @@
 
 /**
  * Inherited Methods
+ *
  * @method void wantToTest($text)
  * @method void wantTo($text)
  * @method void execute($callable)
@@ -15,7 +16,7 @@
  * @method void pause()
  *
  * @SuppressWarnings(PHPMD)
-*/
+ */
 class UnitTester extends \Codeception\Actor
 {
 	use _generated\UnitTesterActions;

--- a/tests/_support/WpunitTester.php
+++ b/tests/_support/WpunitTester.php
@@ -3,6 +3,7 @@
 
 /**
  * Inherited Methods
+ *
  * @method void wantToTest($text)
  * @method void wantTo($text)
  * @method void execute($callable)
@@ -15,7 +16,7 @@
  * @method void pause()
  *
  * @SuppressWarnings(PHPMD)
-*/
+ */
 class WpunitTester extends \Codeception\Actor
 {
 	use _generated\WpunitTesterActions;

--- a/tests/acceptance/forms/FormCest.php
+++ b/tests/acceptance/forms/FormCest.php
@@ -2,17 +2,17 @@
 /**
  * Tests that Feeds work with a Gravity Form and that subscriber data
  * is correctly sent to the API.
- * 
- * @since 	1.2.1
+ *
+ * @since   1.2.1
  */
 class FormCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.2.1
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.2.1
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function _before(AcceptanceTester $I)
 	{
@@ -26,10 +26,10 @@ class FormCest
 	 * - Creating a Gravity Form's Form, and
 	 * - Adding a Feed to send entries to ConvertKit, and
 	 * - Submitting the Form on the frontend web site results in the email address subscribing to the ConvertKit Form.
-	 * 
-	 * @since 	1.2.1
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.2.1
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testCreateFormAndFeed(AcceptanceTester $I)
 	{
@@ -43,8 +43,8 @@ class FormCest
 		$pageID = $I->createPageWithGravityFormShortcode($I, $gravityFormID);
 
 		// Define Name, Email Address and Custom Field Data for this Test.
-		$firstName = 'First';
-		$lastName = 'Last';
+		$firstName    = 'First';
+		$lastName     = 'Last';
 		$emailAddress = $I->generateEmailAddress();
 		$customFields = [
 			'last_name' => $lastName,
@@ -90,10 +90,10 @@ class FormCest
 	 * Test that the Plugin shows an error when:
 	 * - Creating a Gravity Form's Form, and
 	 * - Adding a Feed to send entries to ConvertKit, with no ConvertKit Form selected.
-	 * 
-	 * @since 	1.2.1
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.2.1
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testCreateFormAndFeedWithNoConvertKitFormSelected(AcceptanceTester $I)
 	{
@@ -119,8 +119,8 @@ class FormCest
 		$pageID = $I->createPageWithGravityFormShortcode($I, $gravityFormID);
 
 		// Define Name, Email Address and Custom Field Data for this Test.
-		$firstName = 'First';
-		$lastName = 'Last';
+		$firstName    = 'First';
+		$lastName     = 'Last';
 		$emailAddress = $I->generateEmailAddress();
 
 		// Logout as the WordPress Administrator.
@@ -162,10 +162,10 @@ class FormCest
 	 * - Creating a Gravity Form's Form, and
 	 * - Adding a Feed to send entries to ConvertKit,
 	 * - Submitting the Form on the frontend web site, without an email address, results in no attempt to send data to ConvertKit.
-	 * 
-	 * @since 	1.2.1
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.2.1
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testCreateFormAndFeedWithNoEmailAddressSpecified(AcceptanceTester $I)
 	{
@@ -184,7 +184,7 @@ class FormCest
 
 		// Define Name.
 		$firstName = 'First';
-		$lastName = 'Last';
+		$lastName  = 'Last';
 
 		// Logout as the WordPress Administrator.
 		$I->logOut();
@@ -216,12 +216,12 @@ class FormCest
 	/**
 	 * Test that the Plugin works when:
 	 * - Creating a Gravity Form's Form, and
-	 * - Adding a Feed to send entries to ConvertKit, with the Email mapped to a non-Email field 
+	 * - Adding a Feed to send entries to ConvertKit, with the Email mapped to a non-Email field
 	 * - Submitting the Form on the frontend web site, with an invalid formatted email address, results in no attempt to send data to ConvertKit.
-	 * 
-	 * @since 	1.2.1
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.2.1
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testCreateFormAndFeedWithInvalidEmailAddressSpecified(AcceptanceTester $I)
 	{
@@ -243,7 +243,7 @@ class FormCest
 
 		// Define Name.
 		$firstName = 'First';
-		$lastName = 'Last';
+		$lastName  = 'Last';
 
 		// Logout as the WordPress Administrator.
 		$I->logOut();
@@ -278,10 +278,10 @@ class FormCest
 	 * - Adding a Feed to send entries to ConvertKit, with a Tag selected, and
 	 * - Submitting the Form on the frontend web site, with a Tag selected from the <select> field, results in the email address subscribing to the ConvertKit Form, and
 	 * - The subscribed email address has the expected ConvertKit Tag assigned to it.
-	 * 
-	 * @since 	1.2.1
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.2.1
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testCreateFormAndFeedWithTagAndFieldTagSelected(AcceptanceTester $I)
 	{
@@ -301,8 +301,8 @@ class FormCest
 		$pageID = $I->createPageWithGravityFormShortcode($I, $gravityFormID);
 
 		// Define Name, Email Address and Custom Field Data for this Test.
-		$firstName = 'First';
-		$lastName = 'Last';
+		$firstName    = 'First';
+		$lastName     = 'Last';
 		$emailAddress = $I->generateEmailAddress();
 		$customFields = [
 			'last_name' => $lastName,
@@ -357,10 +357,10 @@ class FormCest
 	 * - Adding a Feed to send entries to ConvertKit, and
 	 * - Submitting the Form on the frontend web site, with a Tag selected from the <select> field, results in the email address subscribing to the ConvertKit Form, and
 	 * - The subscribed email address has the expected ConvertKit Tag assigned to it.
-	 * 
-	 * @since 	1.2.1
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.2.1
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testCreateFormAndFeedWithFieldTagSelected(AcceptanceTester $I)
 	{
@@ -380,8 +380,8 @@ class FormCest
 		$pageID = $I->createPageWithGravityFormShortcode($I, $gravityFormID);
 
 		// Define Name, Email Address and Custom Field Data for this Test.
-		$firstName = 'First';
-		$lastName = 'Last';
+		$firstName    = 'First';
+		$lastName     = 'Last';
 		$emailAddress = $I->generateEmailAddress();
 		$customFields = [
 			'last_name' => $lastName,
@@ -436,10 +436,10 @@ class FormCest
 	 * - Adding a Feed to send entries to ConvertKit, and
 	 * - Submitting the Form on the frontend web site, with an Invalid Tag selected from the <select> field, results in the email address subscribing to the ConvertKit Form, and
 	 * - The subscribed email address has no ConvertKit Tag assigned to it, as the Tag selected does not exist.
-	 * 
-	 * @since 	1.2.1
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.2.1
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testCreateFormAndFeedWithInvalidFieldTagSelected(AcceptanceTester $I)
 	{
@@ -459,8 +459,8 @@ class FormCest
 		$pageID = $I->createPageWithGravityFormShortcode($I, $gravityFormID);
 
 		// Define Name, Email Address and Custom Field Data for this Test.
-		$firstName = 'First';
-		$lastName = 'Last';
+		$firstName    = 'First';
+		$lastName     = 'Last';
 		$emailAddress = $I->generateEmailAddress();
 		$customFields = [
 			'last_name' => $lastName,
@@ -515,10 +515,10 @@ class FormCest
 	 * - Adding a Feed to send entries to ConvertKit, with a Tag selected, and
 	 * - Submitting the Form on the frontend web site results in the email address subscribing to the ConvertKit Form, and
 	 * - The subscribed email address has the expected ConvertKit Tag assigned to it.
-	 * 
-	 * @since 	1.2.1
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.2.1
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testCreateFormAndFeedWithTagSelected(AcceptanceTester $I)
 	{
@@ -538,8 +538,8 @@ class FormCest
 		$pageID = $I->createPageWithGravityFormShortcode($I, $gravityFormID);
 
 		// Define Name, Email Address and Custom Field Data for this Test.
-		$firstName = 'First';
-		$lastName = 'Last';
+		$firstName    = 'First';
+		$lastName     = 'Last';
 		$emailAddress = $I->generateEmailAddress();
 		$customFields = [
 			'last_name' => $lastName,
@@ -593,10 +593,10 @@ class FormCest
 	 * - Adding a Feed to send entries to ConvertKit, and
 	 * - Disabling the Feed (meaning no entries should be sent to ConvertKit), and
 	 * - Submitting the Form on the frontend web site results in the email address not being subscribed to the ConvertKit Form.
-	 * 
-	 * @since 	1.2.1
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.2.1
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testCreateFormAndFeedDisabled(AcceptanceTester $I)
 	{
@@ -618,8 +618,8 @@ class FormCest
 		$pageID = $I->createPageWithGravityFormShortcode($I, $gravityFormID);
 
 		// Define Name, Email Address and Custom Field Data for this Test.
-		$firstName = 'First';
-		$lastName = 'Last';
+		$firstName    = 'First';
+		$lastName     = 'Last';
 		$emailAddress = $I->generateEmailAddress();
 
 		// Logout as the WordPress Administrator.
@@ -664,10 +664,10 @@ class FormCest
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.2.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.2.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function _passed(AcceptanceTester $I)
 	{

--- a/tests/acceptance/forms/FormCest.php
+++ b/tests/acceptance/forms/FormCest.php
@@ -12,7 +12,7 @@ class FormCest
 	 *
 	 * @since   1.2.1
 	 *
-	 * @param   AcceptanceTester $I  Tester
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _before(AcceptanceTester $I)
 	{
@@ -29,7 +29,7 @@ class FormCest
 	 *
 	 * @since   1.2.1
 	 *
-	 * @param   AcceptanceTester $I  Tester
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testCreateFormAndFeed(AcceptanceTester $I)
 	{
@@ -93,7 +93,7 @@ class FormCest
 	 *
 	 * @since   1.2.1
 	 *
-	 * @param   AcceptanceTester $I  Tester
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testCreateFormAndFeedWithNoConvertKitFormSelected(AcceptanceTester $I)
 	{
@@ -165,7 +165,7 @@ class FormCest
 	 *
 	 * @since   1.2.1
 	 *
-	 * @param   AcceptanceTester $I  Tester
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testCreateFormAndFeedWithNoEmailAddressSpecified(AcceptanceTester $I)
 	{
@@ -221,7 +221,7 @@ class FormCest
 	 *
 	 * @since   1.2.1
 	 *
-	 * @param   AcceptanceTester $I  Tester
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testCreateFormAndFeedWithInvalidEmailAddressSpecified(AcceptanceTester $I)
 	{
@@ -281,7 +281,7 @@ class FormCest
 	 *
 	 * @since   1.2.1
 	 *
-	 * @param   AcceptanceTester $I  Tester
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testCreateFormAndFeedWithTagAndFieldTagSelected(AcceptanceTester $I)
 	{
@@ -360,7 +360,7 @@ class FormCest
 	 *
 	 * @since   1.2.1
 	 *
-	 * @param   AcceptanceTester $I  Tester
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testCreateFormAndFeedWithFieldTagSelected(AcceptanceTester $I)
 	{
@@ -439,7 +439,7 @@ class FormCest
 	 *
 	 * @since   1.2.1
 	 *
-	 * @param   AcceptanceTester $I  Tester
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testCreateFormAndFeedWithInvalidFieldTagSelected(AcceptanceTester $I)
 	{
@@ -518,7 +518,7 @@ class FormCest
 	 *
 	 * @since   1.2.1
 	 *
-	 * @param   AcceptanceTester $I  Tester
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testCreateFormAndFeedWithTagSelected(AcceptanceTester $I)
 	{
@@ -596,7 +596,7 @@ class FormCest
 	 *
 	 * @since   1.2.1
 	 *
-	 * @param   AcceptanceTester $I  Tester
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testCreateFormAndFeedDisabled(AcceptanceTester $I)
 	{
@@ -667,7 +667,7 @@ class FormCest
 	 *
 	 * @since   1.2.2
 	 *
-	 * @param   AcceptanceTester $I  Tester
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _passed(AcceptanceTester $I)
 	{

--- a/tests/acceptance/general/ActivateDeactivatePluginCest.php
+++ b/tests/acceptance/general/ActivateDeactivatePluginCest.php
@@ -1,5 +1,9 @@
 <?php
-
+/**
+ * Tests Plugin activation and deactivation works without errors
+ *
+ * @since   1.2.2
+ */
 class ActivateDeactivatePluginCest
 {
 	/**
@@ -8,7 +12,7 @@ class ActivateDeactivatePluginCest
 	 *
 	 * @since   1.2.1
 	 *
-	 * @param   AcceptanceTester $I  Tester
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testPluginActivationDeactivation(AcceptanceTester $I)
 	{
@@ -24,7 +28,7 @@ class ActivateDeactivatePluginCest
 	 *
 	 * @since   1.2.1
 	 *
-	 * @param   AcceptanceTester $I  Tester
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testPluginActivationDeactivationWithoutGravityForms(AcceptanceTester $I)
 	{

--- a/tests/acceptance/general/ActivateDeactivatePluginCest.php
+++ b/tests/acceptance/general/ActivateDeactivatePluginCest.php
@@ -5,10 +5,10 @@ class ActivateDeactivatePluginCest
 	/**
 	 * Test that activating the Plugin and the Gravity Forms Plugins works
 	 * with no errors.
-	 * 
-	 * @since 	1.2.1
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.2.1
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testPluginActivationDeactivation(AcceptanceTester $I)
 	{
@@ -21,10 +21,10 @@ class ActivateDeactivatePluginCest
 	/**
 	 * Test that activating the Plugin, without activating the Gravity Forms Plugin, works
 	 * with no errors.
-	 * 
-	 * @since 	1.2.1
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.2.1
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testPluginActivationDeactivationWithoutGravityForms(AcceptanceTester $I)
 	{

--- a/tests/acceptance/general/AnyErrorsOnBlankInstallCest.php
+++ b/tests/acceptance/general/AnyErrorsOnBlankInstallCest.php
@@ -1,5 +1,10 @@
 <?php
-
+/**
+ * Tests that no errors are output when activating the Plugin on
+ * a blank installation
+ *
+ * @since   1.2.2
+ */
 class AnyErrorsOnBlankInstallCest
 {
 	/**
@@ -8,7 +13,7 @@ class AnyErrorsOnBlankInstallCest
 	 *
 	 * @since   1.2.1
 	 *
-	 * @param   AcceptanceTester $I  Tester
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testSettingsScreen(AcceptanceTester $I)
 	{

--- a/tests/acceptance/general/AnyErrorsOnBlankInstallCest.php
+++ b/tests/acceptance/general/AnyErrorsOnBlankInstallCest.php
@@ -5,10 +5,10 @@ class AnyErrorsOnBlankInstallCest
 	/**
 	 * Check that no PHP errors or notices are displayed at Gravity Forms > Settings > ConvertKit, when the Plugin is activated
 	 * and not configured.
-	 * 
-	 * @since 	1.2.1
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.2.1
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testSettingsScreen(AcceptanceTester $I)
 	{

--- a/tests/acceptance/general/CapabilitiesCest.php
+++ b/tests/acceptance/general/CapabilitiesCest.php
@@ -4,17 +4,17 @@
  * - Add-On Settings (Forms > Settings > ConvertKit)
  * - Form Settings (Forms > Edit Form > Settings > ConvertKit)
  * - Uninstall (Forms > Settings > Uninstall > ConvertKit)
- * 
- * @since 	1.2.5
+ *
+ * @since   1.2.5
  */
 class CapabilitiesCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.2.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.2.5
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function _before(AcceptanceTester $I)
 	{
@@ -26,10 +26,10 @@ class CapabilitiesCest
 	/**
 	 * Test that a WordPress User assigned a Role with the Add-On Settings capability enabled
 	 * can access the add-on settings screen at Forms > Settings > ConvertKit.
-	 * 
-	 * @since 	1.2.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.2.5
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testAddOnSettingsWhenCapabilityEnabledForRole(AcceptanceTester $I)
 	{
@@ -37,10 +37,14 @@ class CapabilitiesCest
 		$I->createGravityFormsRole($I, true, false, false);
 
 		// Create User, assigned to the Role.
-		$I->haveUserInDatabase('gravity_forms_user', 'gravity_forms', [
-			'user_email' 	=> 'gravity_forms_user@test.local',
-			'user_pass' 	=> $_ENV['TEST_SITE_ADMIN_PASSWORD'],
-		]);
+		$I->haveUserInDatabase(
+			'gravity_forms_user',
+			'gravity_forms',
+			[
+				'user_email' => 'gravity_forms_user@test.local',
+				'user_pass'  => $_ENV['TEST_SITE_ADMIN_PASSWORD'],
+			]
+		);
 
 		// Logout.
 		$I->logOut();
@@ -58,10 +62,10 @@ class CapabilitiesCest
 	/**
 	 * Test that a WordPress User assigned a Role with the Add-On Settings capability disabled
 	 * cannot access the add-on settings screen at Forms > Settings > ConvertKit.
-	 * 
-	 * @since 	1.2.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.2.5
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testAddOnSettingsWhenCapabilityDisabledForRole(AcceptanceTester $I)
 	{
@@ -69,10 +73,14 @@ class CapabilitiesCest
 		$I->createGravityFormsRole($I, false, false, false);
 
 		// Create User, assigned to the Role.
-		$I->haveUserInDatabase('gravity_forms_user', 'gravity_forms', [
-			'user_email' 	=> 'gravity_forms_user@test.local',
-			'user_pass' 	=> $_ENV['TEST_SITE_ADMIN_PASSWORD'],
-		]);
+		$I->haveUserInDatabase(
+			'gravity_forms_user',
+			'gravity_forms',
+			[
+				'user_email' => 'gravity_forms_user@test.local',
+				'user_pass'  => $_ENV['TEST_SITE_ADMIN_PASSWORD'],
+			]
+		);
 
 		// Logout.
 		$I->logOut();
@@ -90,10 +98,10 @@ class CapabilitiesCest
 	/**
 	 * Test that a WordPress User assigned a Role with the Form Settings capability enabled
 	 * can access the add-on settings screen at Forms > Edit Form > Settings > ConvertKit.
-	 * 
-	 * @since 	1.2.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.2.5
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testFormSettingsWhenCapabilityEnabledForRole(AcceptanceTester $I)
 	{
@@ -101,10 +109,14 @@ class CapabilitiesCest
 		$I->createGravityFormsRole($I, false, true, false);
 
 		// Create User, assigned to the Role.
-		$I->haveUserInDatabase('gravity_forms_user', 'gravity_forms', [
-			'user_email' 	=> 'gravity_forms_user@test.local',
-			'user_pass' 	=> $_ENV['TEST_SITE_ADMIN_PASSWORD'],
-		]);
+		$I->haveUserInDatabase(
+			'gravity_forms_user',
+			'gravity_forms',
+			[
+				'user_email' => 'gravity_forms_user@test.local',
+				'user_pass'  => $_ENV['TEST_SITE_ADMIN_PASSWORD'],
+			]
+		);
 
 		// Logout.
 		$I->logOut();
@@ -116,7 +128,7 @@ class CapabilitiesCest
 		$gravityFormID = $I->createGravityFormsForm($I);
 
 		// Go to the Form's Settings Screen.
-		$I->amOnAdminPage('admin.php?page=gf_edit_forms&view=settings&subview=ckgf&id='.$gravityFormID);
+		$I->amOnAdminPage('admin.php?page=gf_edit_forms&view=settings&subview=ckgf&id=' . $gravityFormID);
 
 		// Confirm that ConvertKit Feeds are displayed.
 		$I->seeInSource('ConvertKit Feeds');
@@ -125,10 +137,10 @@ class CapabilitiesCest
 	/**
 	 * Test that a WordPress User assigned a Role with the Form Settings capability disabled
 	 * cannot access the add-on settings screen at Forms > Edit Form > Settings > ConvertKit.
-	 * 
-	 * @since 	1.2.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.2.5
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testFormSettingsWhenCapabilityDisabledForRole(AcceptanceTester $I)
 	{
@@ -136,10 +148,14 @@ class CapabilitiesCest
 		$I->createGravityFormsRole($I, false, false, false);
 
 		// Create User, assigned to the Role.
-		$I->haveUserInDatabase('gravity_forms_user', 'gravity_forms', [
-			'user_email' 	=> 'gravity_forms_user@test.local',
-			'user_pass' 	=> $_ENV['TEST_SITE_ADMIN_PASSWORD'],
-		]);
+		$I->haveUserInDatabase(
+			'gravity_forms_user',
+			'gravity_forms',
+			[
+				'user_email' => 'gravity_forms_user@test.local',
+				'user_pass'  => $_ENV['TEST_SITE_ADMIN_PASSWORD'],
+			]
+		);
 
 		// Logout.
 		$I->logOut();
@@ -151,7 +167,7 @@ class CapabilitiesCest
 		$gravityFormID = $I->createGravityFormsForm($I);
 
 		// Go to the Form's Settings Screen.
-		$I->amOnAdminPage('admin.php?page=gf_edit_forms&view=settings&subview=ckgf&id='.$gravityFormID);
+		$I->amOnAdminPage('admin.php?page=gf_edit_forms&view=settings&subview=ckgf&id=' . $gravityFormID);
 
 		// Confirm that ConvertKit Feeds are displayed.
 		$I->dontSeeInSource('ConvertKit Feeds');
@@ -160,10 +176,10 @@ class CapabilitiesCest
 	/**
 	 * Test that a WordPress User assigned a Role with the Uninstall capability enabled
 	 * can access the add-on uninstall functionality at Forms > Settings > Uninstall.
-	 * 
-	 * @since 	1.2.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.2.5
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testUninstallWhenCapabilityEnabledForRole(AcceptanceTester $I)
 	{
@@ -171,10 +187,14 @@ class CapabilitiesCest
 		$I->createGravityFormsRole($I, false, false, true);
 
 		// Create User, assigned to the Role.
-		$I->haveUserInDatabase('gravity_forms_user', 'gravity_forms', [
-			'user_email' 	=> 'gravity_forms_user@test.local',
-			'user_pass' 	=> $_ENV['TEST_SITE_ADMIN_PASSWORD'],
-		]);
+		$I->haveUserInDatabase(
+			'gravity_forms_user',
+			'gravity_forms',
+			[
+				'user_email' => 'gravity_forms_user@test.local',
+				'user_pass'  => $_ENV['TEST_SITE_ADMIN_PASSWORD'],
+			]
+		);
 
 		// Logout.
 		$I->logOut();
@@ -192,10 +212,10 @@ class CapabilitiesCest
 	/**
 	 * Test that a WordPress User assigned a Role with the Uninstall capability disabled
 	 * cannot access the add-on uninstall functionality at Forms > Settings > Uninstall.
-	 * 
-	 * @since 	1.2.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.2.5
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testUninstallWhenCapabilityDisabledForRole(AcceptanceTester $I)
 	{
@@ -203,10 +223,14 @@ class CapabilitiesCest
 		$I->createGravityFormsRole($I, false, false, false);
 
 		// Create User, assigned to the Role.
-		$I->haveUserInDatabase('gravity_forms_user', 'gravity_forms', [
-			'user_email' 	=> 'gravity_forms_user@test.local',
-			'user_pass' 	=> $_ENV['TEST_SITE_ADMIN_PASSWORD'],
-		]);
+		$I->haveUserInDatabase(
+			'gravity_forms_user',
+			'gravity_forms',
+			[
+				'user_email' => 'gravity_forms_user@test.local',
+				'user_pass'  => $_ENV['TEST_SITE_ADMIN_PASSWORD'],
+			]
+		);
 
 		// Logout.
 		$I->logOut();
@@ -225,10 +249,10 @@ class CapabilitiesCest
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.2.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.2.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function _passed(AcceptanceTester $I)
 	{

--- a/tests/acceptance/general/CapabilitiesCest.php
+++ b/tests/acceptance/general/CapabilitiesCest.php
@@ -14,7 +14,7 @@ class CapabilitiesCest
 	 *
 	 * @since   1.2.5
 	 *
-	 * @param   AcceptanceTester $I  Tester
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _before(AcceptanceTester $I)
 	{
@@ -29,7 +29,7 @@ class CapabilitiesCest
 	 *
 	 * @since   1.2.5
 	 *
-	 * @param   AcceptanceTester $I  Tester
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testAddOnSettingsWhenCapabilityEnabledForRole(AcceptanceTester $I)
 	{
@@ -65,7 +65,7 @@ class CapabilitiesCest
 	 *
 	 * @since   1.2.5
 	 *
-	 * @param   AcceptanceTester $I  Tester
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testAddOnSettingsWhenCapabilityDisabledForRole(AcceptanceTester $I)
 	{
@@ -101,7 +101,7 @@ class CapabilitiesCest
 	 *
 	 * @since   1.2.5
 	 *
-	 * @param   AcceptanceTester $I  Tester
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testFormSettingsWhenCapabilityEnabledForRole(AcceptanceTester $I)
 	{
@@ -140,7 +140,7 @@ class CapabilitiesCest
 	 *
 	 * @since   1.2.5
 	 *
-	 * @param   AcceptanceTester $I  Tester
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testFormSettingsWhenCapabilityDisabledForRole(AcceptanceTester $I)
 	{
@@ -179,7 +179,7 @@ class CapabilitiesCest
 	 *
 	 * @since   1.2.5
 	 *
-	 * @param   AcceptanceTester $I  Tester
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testUninstallWhenCapabilityEnabledForRole(AcceptanceTester $I)
 	{
@@ -215,7 +215,7 @@ class CapabilitiesCest
 	 *
 	 * @since   1.2.5
 	 *
-	 * @param   AcceptanceTester $I  Tester
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testUninstallWhenCapabilityDisabledForRole(AcceptanceTester $I)
 	{
@@ -252,7 +252,7 @@ class CapabilitiesCest
 	 *
 	 * @since   1.2.2
 	 *
-	 * @param   AcceptanceTester $I  Tester
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _passed(AcceptanceTester $I)
 	{

--- a/tests/acceptance/general/ReviewRequestCest.php
+++ b/tests/acceptance/general/ReviewRequestCest.php
@@ -11,7 +11,7 @@ class ReviewRequestCest
 	 *
 	 * @since   1.2.2
 	 *
-	 * @param   AcceptanceTester $I  Tester
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _before(AcceptanceTester $I)
 	{
@@ -24,7 +24,7 @@ class ReviewRequestCest
 	 *
 	 * @since   1.2.2
 	 *
-	 * @param   AcceptanceTester $I  Tester
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testReviewRequestNotificationDisplayed(AcceptanceTester $I)
 	{
@@ -49,7 +49,7 @@ class ReviewRequestCest
 	 *
 	 * @since   1.2.2
 	 *
-	 * @param   AcceptanceTester $I  Tester
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testReviewRequestNotificationDismissed(AcceptanceTester $I)
 	{
@@ -80,7 +80,7 @@ class ReviewRequestCest
 	 *
 	 * @since   1.2.2
 	 *
-	 * @param   AcceptanceTester $I  Tester
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _passed(AcceptanceTester $I)
 	{

--- a/tests/acceptance/general/ReviewRequestCest.php
+++ b/tests/acceptance/general/ReviewRequestCest.php
@@ -1,17 +1,17 @@
 <?php
 /**
  * Tests the ConvertKit Review Notification.
- * 
- * @since 	1.2.2
+ *
+ * @since   1.2.2
  */
 class ReviewRequestCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.2.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.2.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function _before(AcceptanceTester $I)
 	{
@@ -21,10 +21,10 @@ class ReviewRequestCest
 	/**
 	 * Test that the review request is displayed when the options table entries
 	 * have the required values to display the review request notification.
-	 * 
-	 * @since 	1.2.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.2.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testReviewRequestNotificationDisplayed(AcceptanceTester $I)
 	{
@@ -46,10 +46,10 @@ class ReviewRequestCest
 	/**
 	 * Test that the review request is dismissed and does not reappear
 	 * on a subsequent page load.
-	 * 
-	 * @since 	1.2.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.2.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testReviewRequestNotificationDismissed(AcceptanceTester $I)
 	{
@@ -77,10 +77,10 @@ class ReviewRequestCest
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.2.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.2.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function _passed(AcceptanceTester $I)
 	{

--- a/tests/acceptance/general/SettingCest.php
+++ b/tests/acceptance/general/SettingCest.php
@@ -1,17 +1,17 @@
 <?php
 /**
  * Tests the Settings at Forms > Settings > ConvertKit.
- * 
- * @since 	1.2.1
+ *
+ * @since   1.2.1
  */
 class SettingCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.2.1
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.2.1
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function _before(AcceptanceTester $I)
 	{
@@ -22,10 +22,10 @@ class SettingCest
 	/**
 	 * Test that no PHP errors or notices are displayed on the Plugin's Setting screen when the Update Settings
 	 * button is pressed and no settings are specified at Gravity Forms > Settings > ConvertKit.
-	 * 
-	 * @since 	1.2.1
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.2.1
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testSaveBlankSettings(AcceptanceTester $I)
 	{
@@ -46,10 +46,10 @@ class SettingCest
 	 * Test that no PHP errors or notices are displayed on the Plugin's Setting screen,
 	 * and no warning is displayed that the supplied API credentials are invalid, when
 	 * saving valid API credentials at WooCommerce > Settings > Integration > ConvertKit.
-	 * 
-	 * @since 	1.2.1
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.2.1
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testSaveValidAPICredentials(AcceptanceTester $I)
 	{
@@ -61,10 +61,10 @@ class SettingCest
 	 * Test that no PHP errors or notices are displayed on the Plugin's Setting screen,
 	 * and a warning is displayed that the supplied API credentials are invalid, when
 	 * saving invalid API credentials at WooCommerce > Settings > Integration > ConvertKit.
-	 * 
-	 * @since 	1.2.1
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.2.1
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testSaveInvalidAPICredentials(AcceptanceTester $I)
 	{
@@ -73,7 +73,7 @@ class SettingCest
 
 		// Complete API Fields.
 		$I->fillField('_gform_setting_api_key', 'invalidApiKey');
-		
+
 		// Click the Save Settings button.
 		$I->click('#gform-settings-save');
 
@@ -93,10 +93,10 @@ class SettingCest
 	/**
 	 * Test that no PHP errors or notices are displayed on the Plugin's Setting screen when the Debug option
 	 * is enabled and disabled, and that the setting is honored.
-	 * 
-	 * @since 	1.2.1
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.2.1
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testEnableAndDisableDebug(AcceptanceTester $I)
 	{
@@ -132,10 +132,10 @@ class SettingCest
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.2.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.2.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function _passed(AcceptanceTester $I)
 	{

--- a/tests/acceptance/general/SettingCest.php
+++ b/tests/acceptance/general/SettingCest.php
@@ -11,7 +11,7 @@ class SettingCest
 	 *
 	 * @since   1.2.1
 	 *
-	 * @param   AcceptanceTester $I  Tester
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _before(AcceptanceTester $I)
 	{
@@ -25,7 +25,7 @@ class SettingCest
 	 *
 	 * @since   1.2.1
 	 *
-	 * @param   AcceptanceTester $I  Tester
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testSaveBlankSettings(AcceptanceTester $I)
 	{
@@ -49,7 +49,7 @@ class SettingCest
 	 *
 	 * @since   1.2.1
 	 *
-	 * @param   AcceptanceTester $I  Tester
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testSaveValidAPICredentials(AcceptanceTester $I)
 	{
@@ -64,7 +64,7 @@ class SettingCest
 	 *
 	 * @since   1.2.1
 	 *
-	 * @param   AcceptanceTester $I  Tester
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testSaveInvalidAPICredentials(AcceptanceTester $I)
 	{
@@ -96,7 +96,7 @@ class SettingCest
 	 *
 	 * @since   1.2.1
 	 *
-	 * @param   AcceptanceTester $I  Tester
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testEnableAndDisableDebug(AcceptanceTester $I)
 	{
@@ -135,7 +135,7 @@ class SettingCest
 	 *
 	 * @since   1.2.2
 	 *
-	 * @param   AcceptanceTester $I  Tester
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _passed(AcceptanceTester $I)
 	{


### PR DESCRIPTION
## Summary

Applies coding standards for tests, as we do for the [main ConvertKit Plugin](https://github.com/ConvertKit/convertkit-wordpress/pull/380).

This PR includes whitespace fixes; a [separate PR](https://github.com/ConvertKit/convertkit-gravity-forms/pull/68) covers fixes for other coding standards in tests, which means the coding standards GitHub Action will fail at this time.

## Testing

Existing tests are run.

## Checklist

* [x] I have [written a test](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)