### PR TITLE
Run Tests and Coding Standards against WordPress 6.1

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -35,7 +35,7 @@ jobs:
     # Defines the WordPress and PHP Versions matrix to run tests on.
     strategy:
       matrix:
-        wp-versions: [ '6.0.1' ] #[ '5.6.7', '5.7.5', '5.8.3', '5.9' ]
+        wp-versions: [ '6.1' ] #[ '5.6.7', '5.7.5', '5.8.3', '5.9' ]
         php-versions: [ '7.2', '7.3', '7.4', '8.0', '8.1' ] #[ '7.3', '7.4', '8.0', '8.1' ]
 
     # Steps to install, configure and run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
     # For PHP, make sure that an nginx configuration file exists for the required PHP version in this repository at tests/nginx/php-x.x.conf
     strategy:
       matrix:
-        wp-versions: [ '6.1-RC5' ] #[ '5.6.7', '5.7.5', '5.8.3', '5.9' ]
+        wp-versions: [ '6.1' ] #[ '5.6.7', '5.7.5', '5.8.3', '5.9' ]
         php-versions: [ '7.4', '8.0' ] #[ '7.3', '7.4', '8.0', '8.1' ]
         
         # Folder names within the 'tests' folder to run tests in parallel.


### PR DESCRIPTION
## Summary

Run Tests and Coding Standards against WordPress 6.1, released November 1st.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)