### PR TITLE
Run tests against PHP 8.2

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       matrix:
         wp-versions: [ 'latest' ] #[ '6.1.1', 'latest' ]
-        php-versions: [ '7.2', '7.3', '7.4', '8.0', '8.1' ] #[ '7.3', '7.4', '8.0', '8.1' ]
+        php-versions: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2' ] #[ '7.3', '7.4', '8.0', '8.1' ]
 
     # Steps to install, configure and run tests
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       matrix:
         wp-versions: [ 'latest' ] #[ '6.1.1', 'latest' ]
-        php-versions: [ '7.4', '8.0', '8.1' ] #[ '7.4', '8.0', '8.1' ]
+        php-versions: [ '7.4', '8.0', '8.1', '8.2' ] #[ '7.4', '8.0', '8.1' ]
         
         # Folder names within the 'tests' folder to run tests in parallel.
         test-groups: [
@@ -115,9 +115,9 @@ jobs:
         run: wp-cli plugin install ${{ secrets.CONVERTKIT_PAID_PLUGIN_URLS }}
 
       # WP_DEBUG = true is required so all PHP errors are output and caught by tests (E_ALL).
-      # WP_DEBUG = false for PHP 8.1, otherwise E_DEPRECATED is output due to https://core.trac.wordpress.org/ticket/54504
+      # WP_DEBUG = false for PHP 8.1, 8.2, otherwise E_DEPRECATED is output due to https://core.trac.wordpress.org/ticket/54504
       - name: Enable WP_DEBUG
-        if: ${{ matrix.php-versions != '8.1' }}
+        if: ${{ matrix.php-versions != '8.1' && matrix.php-versions != '8.2' }}
         working-directory: ${{ env.ROOT_DIR }}
         run: |
           wp-cli config set WP_DEBUG true --raw

--- a/tests/nginx/php-8.2.conf
+++ b/tests/nginx/php-8.2.conf
@@ -1,0 +1,13 @@
+server {
+    listen 80;
+    root /home/runner/work/convertkit-gravity-forms/convertkit-gravity-forms/wordpress;
+    server_name 127.0.0.1;
+    index index.php;
+    location / {
+        try_files $uri $uri/ /index.php?$args;
+    }
+    location ~ \.php$ {
+        include snippets/fastcgi-php.conf;
+        fastcgi_pass unix:/var/run/php/php8.2-fpm.sock;
+    }
+}


### PR DESCRIPTION
## Summary

Runs tests against PHP 8.2, released December 8th 2022.

`WP_DEBUG` is disabled when running tests against PHP 8.2, due to [this WordPress core](https://core.trac.wordpress.org/ticket/54504) issue that requires resolution to prevent `E_DEPRECATED` notices when performing HTTP requests.

Critical PHP errors and warnings will still result in test failure, however we'll need to reintroduce WP_DEBUG once WordPress resolve the above core issue.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)