### PR TITLE
Return Resources in correct order

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "license": "GPLv3",
     "require": {
-        "convertkit/convertkit-wordpress-libraries": "1.3.0"
+        "convertkit/convertkit-wordpress-libraries": "1.3.1"
     },
     "require-dev": {
         "lucatume/wp-browser": "^3.0",

--- a/includes/class-gfconvertkit.php
+++ b/includes/class-gfconvertkit.php
@@ -652,11 +652,11 @@ class GFConvertKit extends GFFeedAddOn {
 	/**
 	 * Returns the given array of fields (Forms, Tags or Custom Fields)
 	 * in alphabetical ascending order by label.
-	 * 
-	 * @since 	1.3.1
-	 * 
-	 * @param 	array 	$resources 	Resources.
-	 * @return 	array 				Sorted Resources by label
+	 *
+	 * @since   1.3.1
+	 *
+	 * @param   array $resources  Resources.
+	 * @return  array               Sorted Resources by label
 	 */
 	private function sort_fields( $resources ) {
 

--- a/includes/class-gfconvertkit.php
+++ b/includes/class-gfconvertkit.php
@@ -559,6 +559,9 @@ class GFConvertKit extends GFFeedAddOn {
 			);
 		}
 
+		// Sort Forms in ascending order by label.
+		$fields = $this->sort_fields( $fields );
+
 		return $fields;
 
 	}
@@ -595,6 +598,9 @@ class GFConvertKit extends GFFeedAddOn {
 			);
 		}
 
+		// Sort Custom Fields in ascending order by label.
+		$fields = $this->sort_fields( $fields );
+
 		return $fields;
 
 	}
@@ -609,7 +615,7 @@ class GFConvertKit extends GFFeedAddOn {
 	 */
 	private function get_tags() {
 
-		// Get Custom Fields.
+		// Get Tags.
 		$api  = new CKGF_API(
 			$this->api_key(),
 			'',
@@ -636,7 +642,33 @@ class GFConvertKit extends GFFeedAddOn {
 			);
 		}
 
+		// Sort Tags in ascending order by label.
+		$fields = $this->sort_fields( $fields );
+
 		return $fields;
+
+	}
+
+	/**
+	 * Returns the given array of fields (Forms, Tags or Custom Fields)
+	 * in alphabetical ascending order by label.
+	 * 
+	 * @since 	1.3.1
+	 * 
+	 * @param 	array 	$resources 	Resources.
+	 * @return 	array 				Sorted Resources by label
+	 */
+	private function sort_fields( $resources ) {
+
+		// Sort resources ascending by the label property.
+		uasort(
+			$resources,
+			function( $a, $b ) {
+				return strcmp( $a['label'], $b['label'] );
+			}
+		);
+
+		return $resources;
 
 	}
 

--- a/tests/_support/Helper/Acceptance/GravityForms.php
+++ b/tests/_support/Helper/Acceptance/GravityForms.php
@@ -153,8 +153,16 @@ class GravityForms extends \Codeception\Module
 		// Define Feed Name.
 		$I->fillField('_gform_setting_feed_name', 'ConvertKit Feed');
 
+		// Check Forms are displayed in alphabetical order.
+		$I->checkSelectFormOptionOrder($I, '#form_id');
+
 		// Define ConvertKit Form to send entries to.
 		$I->selectOption('_gform_setting_form_id', $formName);
+
+		// Check Tags are displayed in alphabetical order.
+		$I->checkSelectTagOptionOrder($I, '#tag_id', [
+			'(No Tag)',
+		]);
 
 		// Define ConvertKit Tag to apply to subscribers.
 		if ($tagName) {
@@ -173,6 +181,11 @@ class GravityForms extends \Codeception\Module
 		} else {
 			$I->selectOption('#_gform_setting_field_map_tag', 'Select a Field');
 		}
+
+		// Check Custom Fields are displayed in alphabetical order.
+		$I->checkSelectCustomFieldOptionOrder($I, '#_gform_setting_convertkit_custom_fields_custom_key_0', [
+			'Select a Field',
+		]);
 
 		// Map ConvertKit Account Custom Field 'Last Name'.
 		$I->selectOption('#_gform_setting_convertkit_custom_fields_custom_key_0', 'Last Name');

--- a/tests/_support/Helper/Acceptance/GravityForms.php
+++ b/tests/_support/Helper/Acceptance/GravityForms.php
@@ -160,9 +160,13 @@ class GravityForms extends \Codeception\Module
 		$I->selectOption('_gform_setting_form_id', $formName);
 
 		// Check Tags are displayed in alphabetical order.
-		$I->checkSelectTagOptionOrder($I, '#tag_id', [
-			'(No Tag)',
-		]);
+		$I->checkSelectTagOptionOrder(
+			$I,
+			'#tag_id',
+			[
+				'(No Tag)',
+			]
+		);
 
 		// Define ConvertKit Tag to apply to subscribers.
 		if ($tagName) {
@@ -183,9 +187,13 @@ class GravityForms extends \Codeception\Module
 		}
 
 		// Check Custom Fields are displayed in alphabetical order.
-		$I->checkSelectCustomFieldOptionOrder($I, '#_gform_setting_convertkit_custom_fields_custom_key_0', [
-			'Select a Field',
-		]);
+		$I->checkSelectCustomFieldOptionOrder(
+			$I,
+			'#_gform_setting_convertkit_custom_fields_custom_key_0',
+			[
+				'Select a Field',
+			]
+		);
 
 		// Map ConvertKit Account Custom Field 'Last Name'.
 		$I->selectOption('#_gform_setting_convertkit_custom_fields_custom_key_0', 'Last Name');

--- a/tests/_support/Helper/Acceptance/Plugin.php
+++ b/tests/_support/Helper/Acceptance/Plugin.php
@@ -79,6 +79,117 @@ class Plugin extends \Codeception\Module
 	}
 
 	/**
+	 * Helper method to determine that the order of the Form resources in the given
+	 * select element are in the expected alphabetical order.
+	 *
+	 * @since   1.3.1
+	 *
+	 * @param   AcceptanceTester $I                 AcceptanceTester.
+	 * @param   string           $selectElement     <select> element.
+	 * @param   bool|array       $prependOptions    Option elements that should appear before the resources.
+	 */
+	public function checkSelectFormOptionOrder($I, $selectElement, $prependOptions = false)
+	{
+		// Define options.
+		$options = [
+			'AAA Test', // First item.
+			'WooCommerce Product Form', // Last item.
+		];
+
+		// Prepend options, such as 'Default' and 'None' to the options, if required.
+		if ( $prependOptions ) {
+			$options = array_merge( $prependOptions, $options );
+		}
+
+		// Check order.
+		$I->checkSelectOptionOrder($I, $selectElement, $options);
+	}
+
+	/**
+	 * Helper method to determine that the order of the Tag resources in the given
+	 * select element are in the expected alphabetical order.
+	 *
+	 * @since   1.3.1
+	 *
+	 * @param   AcceptanceTester $I                 AcceptanceTester.
+	 * @param   string           $selectElement     <select> element.
+	 * @param   bool|array       $prependOptions    Option elements that should appear before the resources.
+	 */
+	public function checkSelectTagOptionOrder($I, $selectElement, $prependOptions = false)
+	{
+		// Define options.
+		$options = [
+			'gravityforms-tag-1', // First item.
+			'wordpress', // Last item.
+		];
+
+		// Prepend options, such as 'Default' and 'None' to the options, if required.
+		if ( $prependOptions ) {
+			$options = array_merge( $prependOptions, $options );
+		}
+
+		// Check order.
+		$I->checkSelectOptionOrder($I, $selectElement, $options);
+	}
+
+	/**
+	 * Helper method to determine that the order of the Custom Field resources in the given
+	 * select element are in the expected alphabetical order.
+	 *
+	 * @since   1.3.1
+	 *
+	 * @param   AcceptanceTester $I                 AcceptanceTester.
+	 * @param   string           $selectElement     <select> element.
+	 * @param   bool|array       $prependOptions    Option elements that should appear before the resources.
+	 */
+	public function checkSelectCustomFieldOptionOrder($I, $selectElement, $prependOptions = false)
+	{
+		// Define options.
+		$options = [
+			'Billing Address', // First item.
+			'Last Name', // Second item.
+			'Add Custom Key', // Last item.
+		];
+
+		// Prepend options, such as 'Default' and 'None' to the options, if required.
+		if ( $prependOptions ) {
+			$options = array_merge( $prependOptions, $options );
+		}
+
+		// Check order.
+		$I->checkSelectOptionOrder($I, $selectElement, $options);
+	}
+
+	/**
+	 * Helper method to determine the order of <option> values for the given select element
+	 * and values.
+	 *
+	 * @since   1.3.1
+	 *
+	 * @param   AcceptanceTester $I             AcceptanceTester.
+	 * @param   string           $selectElement <select> element.
+	 * @param   array            $values        <option> values.
+	 */
+	public function checkSelectOptionOrder($I, $selectElement, $values)
+	{
+		foreach ( $values as $i => $value ) {
+			// Define the applicable CSS selector.
+			if ( $i === 0 ) {
+				$nth = 'first-child';
+			} elseif ( $i + 1 === count( $values ) ) {
+				$nth = 'last-child';
+			} else {
+				$nth = 'nth-child(' . ( $i + 1 ) . ')';
+			}
+
+			$I->assertEquals(
+				$I->grabTextFrom('select' . $selectElement . ' option:' . $nth),
+				$value
+			);
+		}
+	}
+
+	/**
 	 * Helper method to reset the ConvertKit Plugin settings, as if it's a clean installation.
 	 *
 	 * @since   1.2.2


### PR DESCRIPTION
## Summary

Implements 1.3.1 of the WordPress Libraries, resolving [this issue](https://wordpress.org/support/topic/convertkit-tags-in-woocommerce-not-in-alphabetical-order/), to ensure that Forms, Landing Pages, Tags, Broadcasts and Products are returned in alphabetical order by name.

## Testing

- Added `checkSelect*Order()` helper functions to test that the order of `<select>` dropdown option are correct

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)