### PR TITLE
Test User Agent for API requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,8 @@ jobs:
         # Folder names within the 'tests' folder to run tests in parallel.
         test-groups: [
           'acceptance/forms',
-          'acceptance/general'
+          'acceptance/general',
+          'wpunit'
         ]
 
     # Steps to install, configure and run tests

--- a/tests/wpunit.suite.yml
+++ b/tests/wpunit.suite.yml
@@ -19,4 +19,3 @@ modules:
             adminEmail: "%TEST_SITE_ADMIN_EMAIL%"
             title: "Test"
             plugins: ['convertkit-gravity-forms/convertkit.php'] # Change to the repository Plugin that we're testing.
-            activatePlugins: ['convertkit-gravity-forms/convertkit.php'] # Change to the repository Plugin that we're testing.

--- a/tests/wpunit/APITest.php
+++ b/tests/wpunit/APITest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Tests for the Integrate_ConvertKit_WPForms_API class.
+ * Tests for the CKGF_API class.
  *
  * @since   1.3.1
  */

--- a/tests/wpunit/APITest.php
+++ b/tests/wpunit/APITest.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Tests for the Integrate_ConvertKit_WPForms_API class.
+ *
+ * @since   1.3.1
+ */
+class APITest extends \Codeception\TestCase\WPTestCase
+{
+	/**
+	 * The testing implementation.
+	 *
+	 * @var \WpunitTester.
+	 */
+	protected $tester;
+
+	/**
+	 * Holds the ConvertKit API class.
+	 *
+	 * @since   1.3.1
+	 *
+	 * @var     CKGF_API
+	 */
+	private $api;
+
+	/**
+	 * Performs actions before each test.
+	 *
+	 * @since   1.3.1
+	 */
+	public function setUp(): void
+	{
+		parent::setUp();
+
+		// Activate Plugin, to include the Plugin's constants in tests.
+		activate_plugins('convertkit-gravity-forms/convertkit.php');
+
+		// Include class from /includes to test, as they won't be loaded by the Plugin
+		// because Gravity Forms is not active.
+		require_once 'includes/class-wp-ckgf.php';
+
+		// Initialize the classes we want to test.
+		$this->api = new CKGF_API( $_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET'] );
+	}
+
+	/**
+	 * Performs actions after each test.
+	 *
+	 * @since   1.3.1
+	 */
+	public function tearDown(): void
+	{
+		// Destroy the classes we tested.
+		unset($this->api);
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Test that the User Agent string is in the expected format and
+	 * includes the Plugin's name and version number.
+	 *
+	 * @since   1.3.1
+	 */
+	public function testUserAgent()
+	{
+		// When an API call is made, inspect the user-agent argument.
+		add_filter(
+			'http_request_args',
+			function($args, $url) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter
+				$this->assertStringContainsString(
+					CKGF_PLUGIN_NAME . '/' . CKGF_PLUGIN_VERSION,
+					$args['user-agent']
+				);
+				return $args;
+			},
+			10,
+			2
+		);
+
+		// Perform a request.
+		$result = $this->api->account();
+	}
+}


### PR DESCRIPTION
## Summary

Adds a unit test to confirm that the Plugin's name and version number is in the user-agent string when making API requests.

## Testing

- `APITest`: Unit test to confirm that the correct Plugin name and version number are included in the user-agent string when making API requests.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)