### PR TITLE
Tests: Fix `--headless` flag

### DIFF
--- a/tests/acceptance.suite.yml
+++ b/tests/acceptance.suite.yml
@@ -58,4 +58,4 @@ modules:
             window_size: 1920x1080
             capabilities:
                 chromeOptions:
-                    args: ["--headless", "--disable-gpu"]
+                    args: ["--headless=new", "--disable-gpu"]


### PR DESCRIPTION
## Summary

Use `--headless=new` in acceptance tests, [as required by Chrome 109+](https://github.com/chromium/chromium/commit/e9c516118e2e1923757ecb13e6d9fff36775d1f4).  Resolves issues with some tests failing.

## Testing

- Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)