### PR TITLE
Tests: Conditional Logic

### DIFF
--- a/tests/_support/Helper/Acceptance/GravityForms.php
+++ b/tests/_support/Helper/Acceptance/GravityForms.php
@@ -93,14 +93,15 @@ class GravityForms extends \Codeception\Module
 	 *
 	 * @since   1.2.1
 	 *
-	 * @param   AcceptanceTester $I              AcceptanceTester.
-	 * @param   int              $gravityFormID  Gravity Forms Form ID.
-	 * @param   string           $formName       ConvertKit Form Name.
-	 * @param   mixed            $tagName        ConvertKit Tag Name.
-	 * @param   bool             $mapTagField    Whether to map the Tag field.
-	 * @param   mixed            $emailFieldName Gravity Forms Field Name to map to ConvertKit Email Address.
+	 * @param   AcceptanceTester $I              	AcceptanceTester.
+	 * @param   int              $gravityFormID  	Gravity Forms Form ID.
+	 * @param   string           $formName       	ConvertKit Form Name.
+	 * @param   mixed            $tagName        	ConvertKit Tag Name.
+	 * @param   bool             $mapTagField    	Whether to map the Tag field.
+	 * @param   mixed            $emailFieldName 	Gravity Forms Field Name to map to ConvertKit Email Address.
+	 * @param 	mixed 			 $conditionalLogic 	Whether to configure conditional logic on the feed.
 	 */
-	public function createGravityFormsFeed($I, $gravityFormID, $formName, $tagName = false, $mapTagField = false, $emailFieldName = 'Email')
+	public function createGravityFormsFeed($I, $gravityFormID, $formName, $tagName = false, $mapTagField = false, $emailFieldName = 'Email', $conditionalLogic = false)
 	{
 		// Navigate to Form's Settings > ConvertKit.
 		$I->amOnAdminPage('admin.php?page=gf_edit_forms&view=settings&subview=ckgf&id=' . $gravityFormID);
@@ -109,7 +110,7 @@ class GravityForms extends \Codeception\Module
 		$I->click('#gform-settings div.tablenav.top div.alignright a.button');
 
 		// Complete Feed's Form Fields.
-		$I->completeGravityFormsFeedFields($I, $formName, $tagName, $mapTagField, $emailFieldName);
+		$I->completeGravityFormsFeedFields($I, $formName, $tagName, $mapTagField, $emailFieldName, $conditionalLogic);
 
 		// Click Save Settings.
 		$I->click('#gform-settings-save');
@@ -139,13 +140,14 @@ class GravityForms extends \Codeception\Module
 	 *
 	 * @since   1.2.1
 	 *
-	 * @param   AcceptanceTester $I              AcceptanceTester.
-	 * @param   string           $formName       ConvertKit Form Name.
-	 * @param   mixed            $tagName        ConvertKit Tag Name.
-	 * @param   bool             $mapTagField    Whether to map the Tag field.
-	 * @param   mixed            $emailFieldName Gravity Forms Field Name to map to ConvertKit Email Address.
+	 * @param   AcceptanceTester $I              	AcceptanceTester.
+	 * @param   string           $formName       	ConvertKit Form Name.
+	 * @param   mixed            $tagName        	ConvertKit Tag Name.
+	 * @param   bool             $mapTagField    	Whether to map the Tag field.
+	 * @param   mixed            $emailFieldName 	Gravity Forms Field Name to map to ConvertKit Email Address.
+	 * @param 	mixed 			 $conditionalLogic 	Whether to configure conditional logic on the feed.
 	 */
-	public function completeGravityFormsFeedFields($I, $formName, $tagName = false, $mapTagField = false, $emailFieldName = 'Email')
+	public function completeGravityFormsFeedFields($I, $formName, $tagName = false, $mapTagField = false, $emailFieldName = 'Email', $conditionalLogic)
 	{
 		// Check ConvertKit Form option exists and is populated.
 		$I->seeElementInDOM('select[name="_gform_setting_form_id"]');
@@ -198,6 +200,13 @@ class GravityForms extends \Codeception\Module
 		// Map ConvertKit Account Custom Field 'Last Name'.
 		$I->selectOption('#_gform_setting_convertkit_custom_fields_custom_key_0', 'Last Name');
 		$I->selectOption('#_gform_setting_convertkit_custom_fields_custom_value_0', 'Name (Last)');
+
+		// Configure conditional logic if enabled.
+		if ($conditionalLogic) {
+			$I->checkOption('#feed_condition_conditional_logic');
+			$I->selectOption('#feed_condition_rule_field_0', $conditionalLogic['field']);
+			$I->fillField('#feed_condition_rule_value_0', $conditionalLogic['value']);
+		}
 	}
 
 	/**

--- a/tests/_support/Helper/Acceptance/GravityForms.php
+++ b/tests/_support/Helper/Acceptance/GravityForms.php
@@ -98,13 +98,13 @@ class GravityForms extends \Codeception\Module
 	 *
 	 * @since   1.2.1
 	 *
-	 * @param   AcceptanceTester $I              	AcceptanceTester.
-	 * @param   int              $gravityFormID  	Gravity Forms Form ID.
-	 * @param   string           $formName       	ConvertKit Form Name.
-	 * @param   mixed            $tagName        	ConvertKit Tag Name.
-	 * @param   bool             $mapTagField    	Whether to map the Tag field.
-	 * @param   mixed            $emailFieldName 	Gravity Forms Field Name to map to ConvertKit Email Address.
-	 * @param 	mixed 			 $conditionalLogic 	Whether to configure conditional logic on the feed.
+	 * @param   AcceptanceTester $I                 AcceptanceTester.
+	 * @param   int              $gravityFormID     Gravity Forms Form ID.
+	 * @param   string           $formName          ConvertKit Form Name.
+	 * @param   mixed            $tagName           ConvertKit Tag Name.
+	 * @param   bool             $mapTagField       Whether to map the Tag field.
+	 * @param   mixed            $emailFieldName    Gravity Forms Field Name to map to ConvertKit Email Address.
+	 * @param   mixed            $conditionalLogic  Whether to configure conditional logic on the feed.
 	 */
 	public function createGravityFormsFeed($I, $gravityFormID, $formName, $tagName = false, $mapTagField = false, $emailFieldName = 'Email', $conditionalLogic = false)
 	{
@@ -145,12 +145,12 @@ class GravityForms extends \Codeception\Module
 	 *
 	 * @since   1.2.1
 	 *
-	 * @param   AcceptanceTester $I              	AcceptanceTester.
-	 * @param   string           $formName       	ConvertKit Form Name.
-	 * @param   mixed            $tagName        	ConvertKit Tag Name.
-	 * @param   bool             $mapTagField    	Whether to map the Tag field.
-	 * @param   mixed            $emailFieldName 	Gravity Forms Field Name to map to ConvertKit Email Address.
-	 * @param 	mixed 			 $conditionalLogic 	Whether to configure conditional logic on the feed.
+	 * @param   AcceptanceTester $I                 AcceptanceTester.
+	 * @param   string           $formName          ConvertKit Form Name.
+	 * @param   mixed            $tagName           ConvertKit Tag Name.
+	 * @param   bool             $mapTagField       Whether to map the Tag field.
+	 * @param   mixed            $emailFieldName    Gravity Forms Field Name to map to ConvertKit Email Address.
+	 * @param   mixed            $conditionalLogic  Whether to configure conditional logic on the feed.
 	 */
 	public function completeGravityFormsFeedFields($I, $formName, $tagName = false, $mapTagField = false, $emailFieldName = 'Email', $conditionalLogic)
 	{

--- a/tests/_support/Helper/Acceptance/GravityForms.php
+++ b/tests/_support/Helper/Acceptance/GravityForms.php
@@ -152,7 +152,7 @@ class GravityForms extends \Codeception\Module
 	 * @param   mixed            $emailFieldName    Gravity Forms Field Name to map to ConvertKit Email Address.
 	 * @param   mixed            $conditionalLogic  Whether to configure conditional logic on the feed.
 	 */
-	public function completeGravityFormsFeedFields($I, $formName, $tagName = false, $mapTagField = false, $emailFieldName = 'Email', $conditionalLogic)
+	public function completeGravityFormsFeedFields($I, $formName, $tagName = false, $mapTagField = false, $emailFieldName = 'Email', $conditionalLogic = false)
 	{
 		// Check ConvertKit Form option exists and is populated.
 		$I->seeElementInDOM('select[name="_gform_setting_form_id"]');


### PR DESCRIPTION
## Summary

Adds tests to confirm that an email address is (or is not) subscribed to ConvertKit, depending on how a Gravity Forms Feed's conditional logic is configured.

Created based on [this ticket](https://wordpress.org/support/topic/integration-with-gravity-forms-quiz-add-on/), to confirm that we honor Gravity Forms conditional logic.

## Testing

- `FormCest:testCreateFormAndFeedWithConditionalLogicMatching`: Test that the email is subscribed to ConvertKit when the feed's conditional logic condition is met.
- `FormCest:testCreateFormAndFeedWithConditionalLogicDoesNotMatch`: Test that the email is not subscribed to ConvertKit when the feed's conditional logic is not met.

## Checklist

* [x] I have [written a test](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)