### PR TITLE
Add API Secret Field

### DIFF
--- a/includes/class-gfconvertkit.php
+++ b/includes/class-gfconvertkit.php
@@ -350,7 +350,7 @@ class GFConvertKit extends GFFeedAddOn {
 		}
 
 		// Get Account to test that the API Secret is valid.
-		$api   = new CKGF_API(
+		$api     = new CKGF_API(
 			$this->api_key(),
 			$api_secret,
 			$this->debug_enabled()
@@ -371,7 +371,7 @@ class GFConvertKit extends GFFeedAddOn {
 	 *
 	 * @since   1.3.7
 	 *
-	 * @param   array  $field      	Settings Field.
+	 * @param   array  $field       Settings Field.
 	 * @param   string $api_secret  API Secret.
 	 * @return  bool                API Secret valid
 	 */

--- a/includes/class-gfconvertkit.php
+++ b/includes/class-gfconvertkit.php
@@ -237,6 +237,22 @@ class GFConvertKit extends GFFeedAddOn {
 						'validation_callback' => array( $this, 'plugin_settings_fields_validation_callback_api_key' ),
 					),
 					array(
+						'name'                => 'api_secret',
+						'label'               => esc_html__( 'API Secret', 'convertkit' ),
+						'type'                => 'text',
+						'class'               => 'medium',
+						'required'            => true,
+						'description'         => sprintf(
+							/* translators: %1$s: Link to ConvertKit Account, %2$s: <br>, %3$s Link to ConvertKit Signup */
+							esc_html__( '%1$s Required for proper plugin function. %2$s Don\'t have a ConvertKit account? %3$s', 'convertkit' ),
+							'<p><a href="' . esc_url( ckgf_get_api_key_url() ) . '" target="_blank">' . esc_html__( 'Get your ConvertKit API Secret.', 'convertkit' ) . '</a>',
+							'<br />',
+							'<a href="' . esc_url( ckgf_get_signup_url() ) . '" target="_blank">' . esc_html__( 'Sign up here.', 'convertkit' ) . '</a></p>'
+						),
+						'feedback_callback'   => array( $this, 'plugin_settings_fields_feedback_callback_api_secret' ),
+						'validation_callback' => array( $this, 'plugin_settings_fields_validation_callback_api_secret' ),
+					),
+					array(
 						'name'    => 'debug',
 						'label'   => esc_html__( 'Debug', 'convertkit' ),
 						'type'    => 'checkbox',
@@ -273,7 +289,7 @@ class GFConvertKit extends GFFeedAddOn {
 		// Get Forms to test that the API Key is valid.
 		$api   = new CKGF_API(
 			$api_key,
-			'',
+			$this->api_secret(),
 			$this->debug_enabled()
 		);
 		$forms = $api->get_forms();
@@ -301,12 +317,75 @@ class GFConvertKit extends GFFeedAddOn {
 		// Get Forms to test that the API Key is valid.
 		$api   = new CKGF_API(
 			$api_key,
-			'',
+			$this->api_secret(),
 			$this->debug_enabled()
 		);
 		$forms = $api->get_forms();
 
-		// If an error occured, set the field's error so that an excalamation point with a tooltip is displayed
+		// If an error occured, set the field's error so that an exclamation point with a tooltip is displayed
+		// by Gravity Forms.
+		if ( is_wp_error( $forms ) ) {
+			$this->set_field_error( $field, $forms->get_error_message() );
+			return false;
+		}
+
+		return true;
+
+	}
+
+	/**
+	 * Validate that the API Secret is valid when loading the settings screen, showing a
+	 * tick or a cross.
+	 *
+	 * @since   1.3.7
+	 *
+	 * @param   string $api_secret    API Secret.
+	 * @return  bool                  API Secret valid
+	 */
+	public function plugin_settings_fields_feedback_callback_api_secret( $api_secret ) {
+
+		// Validation fails if the API Secret is empty.
+		if ( empty( $api_secret ) ) {
+			return false;
+		}
+
+		// Get Account to test that the API Secret is valid.
+		$api   = new CKGF_API(
+			$this->api_key(),
+			$api_secret,
+			$this->debug_enabled()
+		);
+		$account = $api->account();
+
+		if ( is_wp_error( $account ) ) {
+			return false;
+		}
+
+		return true;
+
+	}
+
+	/**
+	 * Validate that the API Secret is valid when saving settings, showing a tooltip
+	 * with a contextual message containing the error if the API Secret is invalid.
+	 *
+	 * @since   1.3.7
+	 *
+	 * @param   array  $field      	Settings Field.
+	 * @param   string $api_secret  API Secret.
+	 * @return  bool                API Secret valid
+	 */
+	public function plugin_settings_fields_validation_callback_api_secret( $field, $api_secret ) {
+
+		// Get Account to test that the API Key is valid.
+		$api   = new CKGF_API(
+			$this->api_key(),
+			$api_secret,
+			$this->debug_enabled()
+		);
+		$forms = $api->account();
+
+		// If an error occured, set the field's error so that an exclamation point with a tooltip is displayed
 		// by Gravity Forms.
 		if ( is_wp_error( $forms ) ) {
 			$this->set_field_error( $field, $forms->get_error_message() );
@@ -349,7 +428,7 @@ class GFConvertKit extends GFFeedAddOn {
 		// Get Forms to test that the API Key is valid.
 		$api   = new CKGF_API(
 			$this->api_key(),
-			'',
+			$this->api_secret(),
 			$this->debug_enabled()
 		);
 		$forms = $api->get_forms();
@@ -535,7 +614,7 @@ class GFConvertKit extends GFFeedAddOn {
 		// Get Custom Fields.
 		$api   = new CKGF_API(
 			$this->api_key(),
-			'',
+			$this->api_secret(),
 			$this->debug_enabled()
 		);
 		$forms = $api->get_forms();
@@ -579,7 +658,7 @@ class GFConvertKit extends GFFeedAddOn {
 		// Get Custom Fields.
 		$api           = new CKGF_API(
 			$this->api_key(),
-			'',
+			$this->api_secret(),
 			$this->debug_enabled()
 		);
 		$custom_fields = $api->get_custom_fields();
@@ -618,7 +697,7 @@ class GFConvertKit extends GFFeedAddOn {
 		// Get Tags.
 		$api  = new CKGF_API(
 			$this->api_key(),
-			'',
+			$this->api_secret(),
 			$this->debug_enabled()
 		);
 		$tags = $api->get_tags();
@@ -727,7 +806,7 @@ class GFConvertKit extends GFFeedAddOn {
 		// Initialize API class.
 		$this->api = new CKGF_API(
 			$this->api_key(),
-			'',
+			$this->api_secret(),
 			$this->debug_enabled()
 		);
 
@@ -922,6 +1001,19 @@ class GFConvertKit extends GFFeedAddOn {
 	private function api_key() {
 
 		return $this->get_plugin_setting( 'api_key' );
+
+	}
+
+	/**
+	 * Returns the API Secret defined in the integration's settings.
+	 *
+	 * @since   1.3.7
+	 *
+	 * @return  string
+	 */
+	private function api_secret() {
+
+		return $this->get_plugin_setting( 'api_secret' );
 
 	}
 

--- a/tests/_support/Helper/Acceptance/Plugin.php
+++ b/tests/_support/Helper/Acceptance/Plugin.php
@@ -49,6 +49,7 @@ class Plugin extends \Codeception\Module
 
 		// Complete API Fields.
 		$I->fillField('_gform_setting_api_key', $_ENV['CONVERTKIT_API_KEY']);
+		$I->fillField('_gform_setting_api_secret', $_ENV['CONVERTKIT_API_SECRET']);
 
 		// Click the Save Settings button.
 		$I->click('#gform-settings-save');
@@ -61,6 +62,7 @@ class Plugin extends \Codeception\Module
 
 		// Check the value of the fields match the inputs provided.
 		$I->seeInField('_gform_setting_api_key', $_ENV['CONVERTKIT_API_KEY']);
+		$I->seeInField('_gform_setting_api_key', $_ENV['CONVERTKIT_API_SECRET']);
 	}
 
 	/**

--- a/tests/_support/Helper/Acceptance/Plugin.php
+++ b/tests/_support/Helper/Acceptance/Plugin.php
@@ -62,7 +62,7 @@ class Plugin extends \Codeception\Module
 
 		// Check the value of the fields match the inputs provided.
 		$I->seeInField('_gform_setting_api_key', $_ENV['CONVERTKIT_API_KEY']);
-		$I->seeInField('_gform_setting_api_key', $_ENV['CONVERTKIT_API_SECRET']);
+		$I->seeInField('_gform_setting_api_secret', $_ENV['CONVERTKIT_API_SECRET']);
 	}
 
 	/**

--- a/tests/acceptance.suite.yml
+++ b/tests/acceptance.suite.yml
@@ -58,4 +58,8 @@ modules:
             window_size: 1920x1080
             capabilities:
                 chromeOptions:
-                    args: ["--headless=new", "--disable-gpu"]
+                    args: [
+                        "--headless=new",
+                        "--disable-gpu",
+                        "--user-agent=HeadlessChrome"
+                    ]

--- a/tests/acceptance/general/SettingCest.php
+++ b/tests/acceptance/general/SettingCest.php
@@ -59,14 +59,14 @@ class SettingCest
 
 	/**
 	 * Test that no PHP errors or notices are displayed on the Plugin's Setting screen,
-	 * and a warning is displayed that the supplied API credentials are invalid, when
-	 * saving invalid API credentials at WooCommerce > Settings > Integration > ConvertKit.
+	 * and a warning is displayed that the supplied API Key is invalid, when
+	 * saving an invalid API Key at Forms > Settings > ConvertKit.
 	 *
-	 * @since   1.2.1
+	 * @since   1.3.7
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
-	public function testSaveInvalidAPICredentials(AcceptanceTester $I)
+	public function testSaveInvalidAPIKey(AcceptanceTester $I)
 	{
 		// Go to the Plugin's Settings Screen.
 		$I->loadConvertKitSettingsScreen($I);
@@ -82,6 +82,39 @@ class SettingCest
 
 		// Check the value of the fields match the inputs provided.
 		$I->seeInField('_gform_setting_api_key', 'invalidApiKey');
+
+		// Confirm that a message is displayed telling the user that an error occured whilst saving.
+		$I->seeInSource('There was an error while saving your settings.');
+
+		// Confirm that a tooltip notification exists with the precise API error.
+		$I->seeInSource('Authorization Failed: API Key not valid');
+	}
+
+	/**
+	 * Test that no PHP errors or notices are displayed on the Plugin's Setting screen,
+	 * and a warning is displayed that the supplied API Secret is invalid, when
+	 * saving an invalid API Secret at Forms > Settings > ConvertKit.
+	 *
+	 * @since   1.3.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testSaveInvalidAPISecret(AcceptanceTester $I)
+	{
+		// Go to the Plugin's Settings Screen.
+		$I->loadConvertKitSettingsScreen($I);
+
+		// Complete API Fields.
+		$I->fillField('_gform_setting_api_secret', 'invalidApiSecret');
+
+		// Click the Save Settings button.
+		$I->click('#gform-settings-save');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Check the value of the fields match the inputs provided.
+		$I->seeInField('_gform_setting_api_secret', 'invalidApiSecret');
 
 		// Confirm that a message is displayed telling the user that an error occured whilst saving.
 		$I->seeInSource('There was an error while saving your settings.');


### PR DESCRIPTION
## Summary

Adds an API Secret field to the Plugin's settings, which will be required when [calling the `recommendations_script()` method](https://github.com/ConvertKit/convertkit-wordpress-libraries/pull/23) in a later PR.

![Screenshot 2023-07-12 at 15 08 26](https://github.com/ConvertKit/convertkit-gravity-forms/assets/1462305/64744f39-6838-4898-81a7-77abe11f35c7)

## Testing

- `setupConvertKitPlugin`: Added the API Secret field to the test, confirming correct working functionality when a valid API Secret is specified
- `testSaveInvalidAPIKey`: Test that specifying an invalid API Key returns the expected error
- `testSaveInvalidAPISecret`: Test that specifying an invalid API Secret returns the expected error

## Checklist

* [x] I have [written a test](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)