### PR TITLE
Tests: Improve Performance

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,7 @@ jobs:
         test-groups: [
           'acceptance/forms',
           'acceptance/general',
+          'acceptance/recommendations',
           'wpunit'
         ]
 

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "license": "GPLv3",
     "require": {
-        "convertkit/convertkit-wordpress-libraries": "1.3.6"
+        "convertkit/convertkit-wordpress-libraries": "1.3.7"
     },
     "require-dev": {
         "lucatume/wp-browser": "^3.0",

--- a/includes/class-gfconvertkit.php
+++ b/includes/class-gfconvertkit.php
@@ -130,6 +130,15 @@ class GFConvertKit extends GFFeedAddOn {
 	private static $_instance = null; // phpcs:ignore PSR2.Classes.PropertyDeclaration.Underscore
 
 	/**
+	 * Holds the key to store the Creator Network Recommendations JS URL in.
+	 *
+	 * @since   1.3.7
+	 *
+	 * @var     string
+	 */
+	private $creator_network_recommendations_script_key = 'ckgf_creator_network_recommendations_script';
+
+	/**
 	 * Holds the API instance.
 	 *
 	 * @since   1.2.1
@@ -155,6 +164,199 @@ class GFConvertKit extends GFFeedAddOn {
 				'option_label' => esc_html__( 'Send to ConvertKit only when payment is received.', 'convertkit' ),
 			)
 		);
+
+		// Register fields on the Form Settings screen.
+		add_filter( 'gform_form_settings_fields', array( $this, 'add_form_settings_fields' ), 10, 1 );
+
+		// Output Creator Network Recommendations script, if enabled on the Form.
+		add_filter( 'gform_enqueue_scripts', array( $this, 'maybe_enqueue_creator_network_recommendations_script' ), 10, 2 );
+
+	}
+
+	/**
+	 * Registers a section in each Gravity Forms' "Form Settings" screen, displaying
+	 * an option to enable the Creator Network recommendations script if available on the ConvertKit account.
+	 *
+	 * @since   1.3.7
+	 *
+	 * @param   array $fields     Settings Fields.
+	 * @return  array               Settings Fields
+	 */
+	public function add_form_settings_fields( $fields ) {
+
+		// If "Output HTML5" is disabled at Forms > Settings, don't show an option.
+		// This would render an email field as input[type=text], which the Creator
+		// Network Recommendations script does not recognize.
+		if ( ! (bool) get_option( 'rg_gforms_enable_html5' ) ) {
+			return array_merge(
+				$fields,
+				$this->get_creator_network_form_setting_field(
+					false,
+					sprintf(
+						'%s <a href="%s">%s</a>',
+						esc_html__( 'HTML5 output is required for proper function. Please enable this in ', 'convertkit' ),
+						esc_url( admin_url( 'admin.php?page=gf_settings' ) ),
+						esc_html__( 'Gravity Forms settings.', 'convertkit' )
+					)
+				)
+			);
+		}
+
+		// If no API Key and Secret is specified, don't show an option.
+		if ( ! $this->has_api_key_and_secret() ) {
+			return array_merge(
+				$fields,
+				$this->get_creator_network_form_setting_field(
+					false,
+					sprintf(
+						'%s <a href="%s">%s</a>',
+						esc_html__( 'Please enter your API Key and Secret on the', 'convertkit' ),
+						esc_url( ckgf_get_settings_link() ),
+						esc_html__( 'settings screen', 'convertkit' )
+					)
+				)
+			);
+		}
+
+		// Query API to fetch Creator Network Recommendations script.
+		$result = $this->get_creator_network_recommendations_script( true );
+
+		// If an error occured, don't show an option.
+		if ( is_wp_error( $result ) ) {
+			return array_merge(
+				$fields,
+				$this->get_creator_network_form_setting_field(
+					false,
+					sprintf(
+						'%s. <a href="%s">%s</a>',
+						$result->get_error_message(),
+						esc_url( ckgf_get_settings_link() ),
+						esc_html__( 'Fix settings', 'convertkit' )
+					)
+				)
+			);
+		}
+
+		// If the result is false, the Creator Network is disabled - don't show an option.
+		if ( ! $result ) {
+			return array_merge(
+				$fields,
+				$this->get_creator_network_form_setting_field(
+					false,
+					sprintf(
+						'%s <a href="%s">%s</a>',
+						esc_html__( 'Creator Network Recommendations requires a', 'convertkit' ),
+						esc_url( ckgf_get_settings_billing_url() ),
+						esc_html__( 'paid ConvertKit Plan', 'convertkit' )
+					)
+				)
+			);
+		}
+
+		// Creator Network is enabled.
+		return array_merge(
+			$fields,
+			$this->get_creator_network_form_setting_field(
+				true,
+				__( 'If enabled, displays the Creator Network Recommendations modal when this form is submitted.', 'convertkit' )
+			)
+		);
+
+	}
+
+	/**
+	 * Returns a section and settings field for a Gravity Form when editing its Form Settings,
+	 * to enable/disable the Creator Network Recommendations modal.
+	 *
+	 * @since   1.3.7
+	 *
+	 * @param   bool   $enabled_on_account     Creator Network is available. If false, only the description is returned.
+	 * @param   string $description            Description.
+	 * @return  array                           Settings Fields
+	 */
+	public function get_creator_network_form_setting_field( $enabled_on_account, $description ) {
+
+		// If the Creator Network feature isn't enabled on the ConvertKit account,
+		// just show the description.
+		if ( ! $enabled_on_account ) {
+			return array(
+				'ckgf' => array(
+					'title'  => CKGF_SHORT_TITLE,
+					'fields' => array(
+						array(
+							'name' => 'ckgf_enable_creator_network_recommendations_description',
+							'type' => 'html',
+							'html' => $description,
+						),
+
+						// Ensure that the setting is set to disabled if the form settings are saved.
+						array(
+							'name'  => 'ckgf_enable_creator_network_recommendations',
+							'type'  => 'hidden',
+							'value' => false,
+						),
+					),
+				),
+			);
+		}
+
+		// Return field to toggle the setting.
+		return array(
+			'ckgf' => array(
+				'title'  => CKGF_SHORT_TITLE,
+				'fields' => array(
+					array(
+						'name'    => 'ckgf_enable_creator_network_recommendations',
+						'type'    => 'toggle',
+						'label'   => esc_html__( 'Enable Creator Network Recommendations', 'convertkit' ),
+						'tooltip' => $description,
+					),
+				),
+			),
+		);
+
+	}
+
+	/**
+	 * Enqueues the Creator Network Recommendations script, if the Gravity Forms form
+	 * has the 'Enable Creator Network Recommendations' setting enabled.
+	 *
+	 * @since   1.3.7
+	 *
+	 * @param   array $form       Gravity Forms Form.
+	 * @param   bool  $is_ajax    If AJAX is enabled for form submission.
+	 */
+	public function maybe_enqueue_creator_network_recommendations_script( $form, $is_ajax ) {
+
+		// Bail if AJAX submission is disabled; we can't show the Creator Network Recommendations
+		// if the page reloads on form submission.
+		if ( ! $is_ajax ) {
+			return;
+		}
+
+		// Bail if Creator Network Recommendations are disabled.
+		if ( ! array_key_exists( 'ckgf_enable_creator_network_recommendations', $form ) ) {
+			return;
+		}
+		if ( ! $form['ckgf_enable_creator_network_recommendations'] ) {
+			return;
+		}
+
+		// Fetch Creator Network Recommendations script URL.
+		$script_url = $this->get_creator_network_recommendations_script();
+
+		// Bail if an error occured fetching the script, or no script exists,
+		// because Creator Network Recommendations are not enabled on the
+		// ConvertKit account.
+		if ( is_wp_error( $script_url ) ) {
+			return;
+		}
+		if ( ! $script_url ) {
+			return;
+		}
+
+		// Enqueue script.
+		wp_enqueue_script( 'ckgf-creator-network-recommendations', $script_url, array(), CKGF_PLUGIN_VERSION, true );
 
 	}
 
@@ -1018,6 +1220,45 @@ class GFConvertKit extends GFFeedAddOn {
 	}
 
 	/**
+	 * Returns whether the API Key has been set in the integration's settings.
+	 *
+	 * @since   1.3.7
+	 *
+	 * @return  bool
+	 */
+	private function has_api_key() {
+
+		return ( ! empty( $this->api_key() ) ? true : false );
+
+	}
+
+	/**
+	 * Returns whether the API Secret has been set in the integration's settings.
+	 *
+	 * @since   1.3.7
+	 *
+	 * @return  bool
+	 */
+	private function has_api_secret() {
+
+		return ( ! empty( $this->api_secret() ) ? true : false );
+
+	}
+
+	/**
+	 * Returns whether the API Key and Secret have been set in the integration's settings.
+	 *
+	 * @since   1.3.7
+	 *
+	 * @return  bool
+	 */
+	private function has_api_key_and_secret() {
+
+		return $this->has_api_key() && $this->has_api_secret();
+
+	}
+
+	/**
 	 * Returns whether debug logging is enabled in the integration's settings.
 	 *
 	 * @since   1.2.1
@@ -1027,6 +1268,64 @@ class GFConvertKit extends GFFeedAddOn {
 	private function debug_enabled() {
 
 		return (bool) $this->get_plugin_setting( 'debug' );
+
+	}
+
+	/**
+	 * Fetches the Creator Network Recommendations script from the database, falling
+	 * back to an API query if the database doesn't have a copy of it stored.
+	 *
+	 * @since   1.3.7
+	 *
+	 * @param   bool $force  If enabled, queries the API instead of checking the cached data.
+	 *
+	 * @return  WP_Error|bool|string
+	 */
+	private function get_creator_network_recommendations_script( $force = true ) {
+
+		// Get Creator Network Recommendations script URL.
+		if ( ! $force ) {
+			$script_url = get_option( $this->creator_network_recommendations_script_key );
+			if ( $script_url ) {
+				return $script_url;
+			}
+		}
+
+		// No cached script, or we're forcing an API query; fetch from the API.
+		$api = new CKGF_API(
+			$this->api_key(),
+			$this->api_secret(),
+			$this->debug_enabled()
+		);
+
+		// Sanity check that we're using the ConvertKit WordPress Libraries 1.3.7 or higher.
+		// If another ConvertKit Plugin is active and out of date, its libraries might
+		// be loaded that don't have this method.
+		if ( ! method_exists( $api, 'recommendations_script' ) ) {
+			delete_option( $this->creator_network_recommendations_script_key );
+			return false;
+		}
+
+		// Get script from API.
+		$result = $api->recommendations_script();
+
+		// Bail if an error occured.
+		if ( is_wp_error( $result ) ) {
+			delete_option( $this->creator_network_recommendations_script_key );
+			return $result;
+		}
+
+		// Bail if not enabled.
+		if ( ! $result['enabled'] ) {
+			delete_option( $this->creator_network_recommendations_script_key );
+			return false;
+		}
+
+		// Store script URL, as Creator Network Recommendations are available on this account.
+		update_option( $this->creator_network_recommendations_script_key, $result['embed_js'] );
+
+		// Return.
+		return $result['embed_js'];
 
 	}
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -19,9 +19,8 @@ function ckgf_get_settings_link( $query_args = array() ) {
 	$query_args = array_merge(
 		$query_args,
 		array(
-			'page'    => 'wc-settings',
-			'tab'     => 'integration',
-			'section' => 'ckwc',
+			'page'    => 'gf_settings',
+			'subview' => 'ckgf',
 		)
 	);
 
@@ -65,5 +64,18 @@ function ckgf_get_signup_url() {
 function ckgf_get_api_key_url() {
 
 	return 'https://app.convertkit.com/account_settings/advanced_settings/?utm_source=wordpress&utm_content=convertkit-gravity-forms';
+
+}
+
+/**
+ * Helper method to return the URL the user needs to visit on the ConvertKit app to upgrade their account.
+ *
+ * @since   1.3.7
+ *
+ * @return  string  ConvertKit App URL.
+ */
+function ckgf_get_settings_billing_url() {
+
+	return 'https://app.convertkit.com/account_settings/billing/?utm_source=wordpress&utm_content=convertkit-gravity-forms';
 
 }

--- a/tests/_support/Helper/Acceptance/GravityForms.php
+++ b/tests/_support/Helper/Acceptance/GravityForms.php
@@ -10,6 +10,82 @@ namespace Helper\Acceptance;
 class GravityForms extends \Codeception\Module
 {
 	/**
+	 * Enables HTML5 Output in Gravity Forms.
+	 *
+	 * @since   1.3.7
+	 *
+	 * @param   AcceptanceTester $I     AcceptanceTester.
+	 */
+	public function enableGravityFormsHTML5Output($I)
+	{
+		$I->haveOptionInDatabase('rg_gforms_enable_html5', '1');
+	}
+
+	/**
+	 * Disables HTML5 Output in Gravity Forms.
+	 *
+	 * @since   1.3.7
+	 *
+	 * @param   AcceptanceTester $I     AcceptanceTester.
+	 */
+	public function disableGravityFormsHTML5Output($I)
+	{
+		$I->haveOptionInDatabase('rg_gforms_enable_html5', '0');
+	}
+
+	/**
+	 * Check that the Form Settings screen for the given Gravity Form has a ConvertKit
+	 * section registered, displaying the given message.
+	 *
+	 * @since   1.3.7
+	 *
+	 * @param   AcceptanceTester $I                 AcceptanceTester.
+	 * @param   int              $gravityFormID     Gravity Forms Form ID.
+	 * @param   string           $message           Message.
+	 */
+	public function seeGravityFormsSettingMessage($I, $gravityFormID, $message)
+	{
+		// Navigate to Form's settings.
+		$I->amOnAdminPage('admin.php?page=gf_edit_forms&view=settings&subview=settings&id=' . $gravityFormID);
+
+		// Confirm the ConvertKit settings section exists.
+		$I->seeElementInDOM('#gform-settings-section-convertkit');
+
+		// Confirm a message is displayed telling the user HTML5 output is required.
+		$I->seeInSource($message);
+	}
+
+	/**
+	 * Check that enabling the Creator Network Recommendations on the Form Settings screen
+	 * for the given Gravity Form works.
+	 *
+	 * @since   1.3.7
+	 *
+	 * @param   AcceptanceTester $I                 AcceptanceTester.
+	 * @param   int              $gravityFormID     Gravity Forms Form ID.
+	 */
+	public function enableGravityFormsSettingCreatorNetworkRecommendations($I, $gravityFormID)
+	{
+		// Navigate to Form's settings.
+		$I->amOnAdminPage('admin.php?page=gf_edit_forms&view=settings&subview=settings&id=' . $gravityFormID);
+
+		// Confirm the ConvertKit settings section exists.
+		$I->seeElementInDOM('#gform-settings-section-convertkit');
+
+		// Enable Creator Network Recommendations.
+		$I->click('label[for="_gform_setting_ckgf_enable_creator_network_recommendations"]');
+
+		// Save settings.
+		$I->click('#gform-settings-save');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm settings saved.
+		$I->seeCheckboxIsChecked('#_gform_setting_ckgf_enable_creator_network_recommendations');
+	}
+
+	/**
 	 * Creates a Gravity Forms Form.
 	 *
 	 * @since   1.2.1
@@ -240,9 +316,10 @@ class GravityForms extends \Codeception\Module
 	 *
 	 * @param   AcceptanceTester $I              AcceptanceTester.
 	 * @param   int              $gravityFormID  Gravity Forms Form ID.
+	 * @param   bool             $ajax           Enable AJAX on Form Submission.
 	 * @return  int                                 Page ID
 	 */
-	public function createPageWithGravityFormShortcode($I, $gravityFormID)
+	public function createPageWithGravityFormShortcode($I, $gravityFormID, $ajax = false)
 	{
 		return $I->havePostInDatabase(
 			[
@@ -250,7 +327,7 @@ class GravityForms extends \Codeception\Module
 				'post_status'  => 'publish',
 				'post_name'    => 'gravity-form-' . $gravityFormID,
 				'post_title'   => 'Gravity Form #' . $gravityFormID,
-				'post_content' => '[gravityform id="' . $gravityFormID . '" title="false" description="false"]',
+				'post_content' => '[gravityform id="' . $gravityFormID . '" title="false" description="false" ajax="' . ( $ajax ? 'true' : 'false' ) . '"]',
 			]
 		);
 	}

--- a/tests/_support/Helper/Acceptance/Plugin.php
+++ b/tests/_support/Helper/Acceptance/Plugin.php
@@ -185,6 +185,48 @@ class Plugin extends \Codeception\Module
 	}
 
 	/**
+	 * Check that the given Page does output the Creator Network Recommendations
+	 * script.
+	 *
+	 * @since   1.3.7
+	 *
+	 * @param   AcceptanceTester $I             AcceptanceTester.
+	 * @param   int              $pageID        Page ID.
+	 */
+	public function seeCreatorNetworkRecommendationsScript($I, $pageID)
+	{
+		// Load the Page on the frontend site.
+		$I->amOnPage('/?p=' . $pageID);
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm the recommendations script was not loaded.
+		$I->seeInSource('recommendations.js');
+	}
+
+	/**
+	 * Check that the given Page does not output the Creator Network Recommendations
+	 * script.
+	 *
+	 * @since   1.3.7
+	 *
+	 * @param   AcceptanceTester $I             AcceptanceTester.
+	 * @param   int              $pageID        Page ID.
+	 */
+	public function dontSeeCreatorNetworkRecommendationsScript($I, $pageID)
+	{
+		// Load the Page on the frontend site.
+		$I->amOnPage('/?p=' . $pageID);
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm the recommendations script was not loaded.
+		$I->dontSeeInSource('recommendations.js');
+	}
+
+	/**
 	 * Helper method to reset the ConvertKit Plugin settings, as if it's a clean installation.
 	 *
 	 * @since   1.2.2

--- a/tests/_support/Helper/Acceptance/Plugin.php
+++ b/tests/_support/Helper/Acceptance/Plugin.php
@@ -36,33 +36,26 @@ class Plugin extends \Codeception\Module
 	}
 
 	/**
-	 * Helper method to setup the Plugin's API Key and Secret, and enable the integration.
+	 * Helper method to programmatically setup the Plugin's API Key and Secret,
+	 * enabling debug logging.
 	 *
 	 * @since   1.2.1
 	 *
-	 * @param   AcceptanceTester $I  AcceptanceTester.
+	 * @param   AcceptanceTester $I              AcceptanceTester.
+	 * @param   bool|string      $apiKey         API Key (if specified, used instead of CONVERTKIT_API_KEY).
+	 * @param   bool|string      $apiSecret      API Secret (if specified, used instead of CONVERTKIT_API_SECRET).
+	 * @param   bool|string      $debug          Debug log enabled.
 	 */
-	public function setupConvertKitPlugin($I)
+	public function setupConvertKitPlugin($I, $apiKey = false, $apiSecret = false, $debug = false)
 	{
-		// Go to the Plugin's Settings Screen.
-		$I->loadConvertKitSettingsScreen($I);
-
-		// Complete API Fields.
-		$I->fillField('_gform_setting_api_key', $_ENV['CONVERTKIT_API_KEY']);
-		$I->fillField('_gform_setting_api_secret', $_ENV['CONVERTKIT_API_SECRET']);
-
-		// Click the Save Settings button.
-		$I->click('#gform-settings-save');
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-
-		// Confirm that a message is displayed confirming settings saved.
-		$I->seeInSource('Settings updated.');
-
-		// Check the value of the fields match the inputs provided.
-		$I->seeInField('_gform_setting_api_key', $_ENV['CONVERTKIT_API_KEY']);
-		$I->seeInField('_gform_setting_api_secret', $_ENV['CONVERTKIT_API_SECRET']);
+		$I->haveOptionInDatabase(
+			'gravityformsaddon_ckgf_settings',
+			[
+				'api_key'    => ( $apiKey !== false ? $apiKey : $_ENV['CONVERTKIT_API_KEY'] ),
+				'api_secret' => ( $apiSecret !== false ? $apiSecret : $_ENV['CONVERTKIT_API_SECRET'] ),
+				'debug'      => ( $debug !== false ? '1' : '0' ),
+			]
+		);
 	}
 
 	/**

--- a/tests/acceptance/general/SettingCest.php
+++ b/tests/acceptance/general/SettingCest.php
@@ -153,6 +153,9 @@ class SettingCest
 		// Enable Integration and define its API Keys.
 		$I->setupConvertKitPlugin($I);
 
+		// Go to the Plugin's Settings Screen.
+		$I->loadConvertKitSettingsScreen($I);
+
 		// Check Debug option.
 		$I->checkOption('#debug');
 

--- a/tests/acceptance/general/SettingCest.php
+++ b/tests/acceptance/general/SettingCest.php
@@ -45,16 +45,33 @@ class SettingCest
 	/**
 	 * Test that no PHP errors or notices are displayed on the Plugin's Setting screen,
 	 * and no warning is displayed that the supplied API credentials are invalid, when
-	 * saving valid API credentials at WooCommerce > Settings > Integration > ConvertKit.
+	 * saving valid API credentials at Forms > Settings > ConvertKit.
 	 *
 	 * @since   1.2.1
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
-	public function testSaveValidAPICredentials(AcceptanceTester $I)
+	public function testSaveValidAPIKeyAndSecret(AcceptanceTester $I)
 	{
-		// Enable Integration and define its API Keys.
-		$I->setupConvertKitPlugin($I);
+		// Go to the Plugin's Settings Screen.
+		$I->loadConvertKitSettingsScreen($I);
+
+		// Complete API Fields.
+		$I->fillField('_gform_setting_api_key', $_ENV['CONVERTKIT_API_KEY']);
+		$I->fillField('_gform_setting_api_secret', $_ENV['CONVERTKIT_API_SECRET']);
+
+		// Click the Save Settings button.
+		$I->click('#gform-settings-save');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that a message is displayed confirming settings saved.
+		$I->seeInSource('Settings updated.');
+
+		// Check the value of the fields match the inputs provided.
+		$I->seeInField('_gform_setting_api_key', $_ENV['CONVERTKIT_API_KEY']);
+		$I->seeInField('_gform_setting_api_secret', $_ENV['CONVERTKIT_API_SECRET']);
 	}
 
 	/**

--- a/tests/acceptance/recommendations/RecommendationsCest.php
+++ b/tests/acceptance/recommendations/RecommendationsCest.php
@@ -1,0 +1,284 @@
+<?php
+/**
+ * Tests that the Creator Network Recommendations settings work with a Gravity Form
+ *
+ * @since   1.3.7
+ */
+class RecommendationsCest
+{
+	/**
+	 * Run common actions before running the test functions in this class.
+	 *
+	 * @since   1.3.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function _before(AcceptanceTester $I)
+	{
+		$I->activateConvertKitPlugin($I);
+		$I->activateThirdPartyPlugin($I, 'gravity-forms');
+	}
+
+	/**
+	 * Tests that the 'Enable Creator Network Recommendations' option on a Form's settings
+	 * is not displayed when Gravity Forms 'Output HTML5' is disabled.
+	 *
+	 * @since   1.3.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testCreatorNetworkRecommendationsOptionWhenOutputHTML5Disabled(AcceptanceTester $I)
+	{
+		// Disable Output HTML5 option.
+		$I->disableGravityFormsHTML5Output($I);
+
+		// Create Form.
+		$gravityFormID = $I->createGravityFormsForm($I);
+
+		// Confirm that the Form Settings display the expected error message.
+		$I->seeGravityFormsSettingMessage(
+			$I,
+			$gravityFormID,
+			'HTML5 output is required for proper function. Please enable this in  <a href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-admin/admin.php?page=gf_settings">Gravity Forms settings.</a>'
+		);
+
+		// Create a Page with the Gravity Forms shortcode as its content.
+		$pageID = $I->createPageWithGravityFormShortcode($I, $gravityFormID);
+
+		// Confirm the recommendations script was not loaded.
+		$I->dontSeeCreatorNetworkRecommendationsScript($I, $pageID);
+	}
+
+	/**
+	 * Tests that the 'Enable Creator Network Recommendations' option on a Form's settings
+	 * is not displayed when no API Key and Secret are specified at Forms > Settings > ConvertKit.
+	 *
+	 * @since   1.3.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testCreatorNetworkRecommendationsOptionWhenNoAPIKeyOrSecret(AcceptanceTester $I)
+	{
+		// Enable Output HTML5 option.
+		$I->enableGravityFormsHTML5Output($I);
+
+		// Create Form.
+		$gravityFormID = $I->createGravityFormsForm($I);
+
+		// Confirm that the Form Settings display the expected error message.
+		$I->seeGravityFormsSettingMessage(
+			$I,
+			$gravityFormID,
+			'Please enter your API Key and Secret on the <a href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-admin/admin.php?page=gf_settings&amp;subview=ckgf">settings screen</a>'
+		);
+
+		// Create a Page with the Gravity Forms shortcode as its content.
+		$pageID = $I->createPageWithGravityFormShortcode($I, $gravityFormID);
+
+		// Confirm the recommendations script was not loaded.
+		$I->dontSeeCreatorNetworkRecommendationsScript($I, $pageID);
+	}
+
+	/**
+	 * Tests that the 'Enable Creator Network Recommendations' option on a Form's settings
+	 * is not displayed when no API Secret is specified at Forms > Settings > ConvertKit.
+	 *
+	 * This handles users upgrading from < 1.3.7, where no API Secret setting was provided.
+	 *
+	 * @since   1.3.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testCreatorNetworkRecommendationsOptionWhenNoAPISecret(AcceptanceTester $I)
+	{
+		// Setup Plugin with just the API Key, as if we're upgrading from < 1.3.7.
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY'], '', false);
+
+		// Enable Output HTML5 option.
+		$I->enableGravityFormsHTML5Output($I);
+
+		// Create Form.
+		$gravityFormID = $I->createGravityFormsForm($I);
+
+		// Confirm that the Form Settings display the expected error message.
+		$I->seeGravityFormsSettingMessage(
+			$I,
+			$gravityFormID,
+			'Please enter your API Key and Secret on the <a href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-admin/admin.php?page=gf_settings&amp;subview=ckgf">settings screen</a>'
+		);
+
+		// Create a Page with the Gravity Forms shortcode as its content.
+		$pageID = $I->createPageWithGravityFormShortcode($I, $gravityFormID);
+
+		// Confirm the recommendations script was not loaded.
+		$I->dontSeeCreatorNetworkRecommendationsScript($I, $pageID);
+	}
+
+	/**
+	 * Tests that the 'Enable Creator Network Recommendations' option on a Form's settings
+	 * is not displayed when invalid API Key and Secret are specified at Forms > Settings > ConvertKit.
+	 *
+	 * @since   1.3.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testCreatorNetworkRecommendationsOptionWhenInvalidAPIKeyAndSecret(AcceptanceTester $I)
+	{
+		// Setup Plugin with invalid API Key and Secret.
+		$I->setupConvertKitPlugin($I, 'fakeApiKey', 'fakeApiSecret');
+
+		// Enable Output HTML5 option.
+		$I->enableGravityFormsHTML5Output($I);
+
+		// Create Form.
+		$gravityFormID = $I->createGravityFormsForm($I);
+
+		// Confirm that the Form Settings display the expected error message.
+		$I->seeGravityFormsSettingMessage(
+			$I,
+			$gravityFormID,
+			'Authorization Failed: API Secret not valid. <a href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-admin/admin.php?page=gf_settings&amp;subview=ckgf">Fix settings</a>'
+		);
+
+		// Create a Page with the Gravity Forms shortcode as its content.
+		$pageID = $I->createPageWithGravityFormShortcode($I, $gravityFormID);
+
+		// Confirm the recommendations script was not loaded.
+		$I->dontSeeCreatorNetworkRecommendationsScript($I, $pageID);
+	}
+
+	/**
+	 * Tests that the 'Enable Creator Network Recommendations' option on a Form's settings
+	 * is not displayed when valid API Key and Secret are specified at Forms > Settings > ConvertKit,
+	 * but the ConvertKit account does not have the Creator Network enabled.
+	 *
+	 * @since   1.3.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testCreatorNetworkRecommendationsOptionWhenDisabledOnConvertKitAccount(AcceptanceTester $I)
+	{
+		// Setup Plugin with API Key and Secret for ConvertKit Account that does not have the Creator Network enabled.
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY_NO_DATA'], $_ENV['CONVERTKIT_API_SECRET_NO_DATA']);
+
+		// Enable Output HTML5 option.
+		$I->enableGravityFormsHTML5Output($I);
+
+		// Create Form.
+		$gravityFormID = $I->createGravityFormsForm($I);
+
+		// Confirm that the Form Settings display the expected error message.
+		$I->seeGravityFormsSettingMessage(
+			$I,
+			$gravityFormID,
+			'Creator Network Recommendations requires a <a href="https://app.convertkit.com/account_settings/billing/?utm_source=wordpress&amp;utm_content=convertkit-gravity-forms">paid ConvertKit Plan</a>'
+		);
+
+		// Create a Page with the Gravity Forms shortcode as its content.
+		$pageID = $I->createPageWithGravityFormShortcode($I, $gravityFormID);
+
+		// Confirm the recommendations script was not loaded.
+		$I->dontSeeCreatorNetworkRecommendationsScript($I, $pageID);
+	}
+
+	/**
+	 * Tests that the 'Enable Creator Network Recommendations' option on a Form's settings
+	 * is displayed and saves correctly when valid API Key and Secret are specified at Forms > Settings > ConvertKit,
+	 * and the ConvertKit account has the Creator Network enabled.  Viewing and submitting the Form does not
+	 * display the Creator Network Recommendations modal, because the form submission will reload the page,
+	 * which isn't supported right now.
+	 *
+	 * @since   1.3.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testCreatorNetworkRecommendationsWithAJAXDisabled(AcceptanceTester $I)
+	{
+		// Setup Plugin.
+		$I->setupConvertKitPlugin($I);
+
+		// Enable Output HTML5 option.
+		$I->enableGravityFormsHTML5Output($I);
+
+		// Create Form.
+		$gravityFormID = $I->createGravityFormsForm($I);
+
+		// Enable Creator Network Recommendations on the form's settings.
+		$I->enableGravityFormsSettingCreatorNetworkRecommendations($I, $gravityFormID);
+
+		// Create a Page with the Gravity Forms shortcode as its content.
+		$pageID = $I->createPageWithGravityFormShortcode($I, $gravityFormID);
+
+		// Confirm the recommendations script was not loaded, because AJAX was disabled on the form.
+		$I->dontSeeCreatorNetworkRecommendationsScript($I, $pageID);
+	}
+
+	/**
+	 * Tests that the 'Enable Creator Network Recommendations' option on a Form's settings
+	 * is displayed and saves correctly when valid API Key and Secret are specified at Forms > Settings > ConvertKit,
+	 * and the ConvertKit account has the Creator Network enabled.  Viewing and submitting the Form then correctly
+	 * displays the Creator Network Recommendations modal.
+	 *
+	 * @since   1.3.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testCreatorNetworkRecommendationsWithAJAXEnabled(AcceptanceTester $I)
+	{
+		// Setup Plugin.
+		$I->setupConvertKitPlugin($I);
+
+		// Enable Output HTML5 option.
+		$I->enableGravityFormsHTML5Output($I);
+
+		// Create Form.
+		$gravityFormID = $I->createGravityFormsForm($I);
+
+		// Enable Creator Network Recommendations on the form's settings.
+		$I->enableGravityFormsSettingCreatorNetworkRecommendations($I, $gravityFormID);
+
+		// Create a Page with the Gravity Forms shortcode as its content.
+		$pageID = $I->createPageWithGravityFormShortcode($I, $gravityFormID, true);
+
+		// Confirm the recommendations script was loaded.
+		$I->seeCreatorNetworkRecommendationsScript($I, $pageID);
+
+		// Complete Form Fields.
+		$I->fillField('.name_first input[type=text]', 'First');
+		$I->fillField('.name_last input[type=text]', 'Last');
+		$I->fillField('.ginput_container_email input[type=email]', $I->generateEmailAddress());
+
+		// Submit Form.
+		$I->click('Submit');
+
+		// Wait for Creator Network Recommendations modal to display.
+		$I->waitForElementVisible('.formkit-modal');
+		$I->switchToIFrame('.formkit-modal iframe');
+		$I->waitForElementVisible('div[data-component="Page"]');
+		$I->switchToIFrame();
+
+		// Close the modal.
+		$I->click('.formkit-modal button.formkit-close');
+
+		// Confirm that the underlying Gravity Form submitted successfully.
+		$I->waitForElementNotVisible('.formkit-modal');
+		$I->seeElementInDOM('.gform_confirmation_message');
+		$I->see('Thanks for contacting us! We will get in touch with you shortly.');
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 *
+	 * @since   1.3.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->deactivateConvertKitPlugin($I);
+		$I->deactivateThirdPartyPlugin($I, 'gravity-forms');
+		$I->resetConvertKitPlugin($I);
+	}
+}


### PR DESCRIPTION
## Summary

Improves test performance by programmatically writing the supplied API Key, Secret and debug setting when using the `setupConvertKitPlugin()` helper method, as we do for the main ConvertKit Plugin.

Renames `testSaveValidAPICredentials ` to `testSaveValidAPIKeyAndSecret` for clarity; this test now performs the manual steps in the UI, as `setupConvertKitPlugin()` programmatically defines the API Key, Secret and debug log settings.

Before:
![Screenshot 2023-07-13 at 18 23 16](https://github.com/ConvertKit/convertkit-gravity-forms/assets/1462305/87fc3c33-e9ce-4919-b5ec-7b53b6c55506)

After:
![Screenshot 2023-07-13 at 18 23 11](https://github.com/ConvertKit/convertkit-gravity-forms/assets/1462305/d537b775-d0b0-4fb6-ba7e-3cb53fa53b59)

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)