### PR TITLE
Add Creator Network Recommendations

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,7 @@ jobs:
         test-groups: [
           'acceptance/forms',
           'acceptance/general',
+          'acceptance/recommendations',
           'wpunit'
         ]
 

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "license": "GPLv3",
     "require": {
-        "convertkit/convertkit-wordpress-libraries": "dev-get-recommendations-script"
+        "convertkit/convertkit-wordpress-libraries": "1.3.7"
     },
     "require-dev": {
         "lucatume/wp-browser": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "license": "GPLv3",
     "require": {
-        "convertkit/convertkit-wordpress-libraries": "1.3.6"
+        "convertkit/convertkit-wordpress-libraries": "dev-get-recommendations-script"
     },
     "require-dev": {
         "lucatume/wp-browser": "^3.0",

--- a/includes/class-gfconvertkit.php
+++ b/includes/class-gfconvertkit.php
@@ -281,7 +281,7 @@ class GFConvertKit extends GFFeedAddOn {
 		if ( ! $enabled_on_account ) {
 			return array(
 				'ckgf' => array(
-					'title'  => CKGF_TITLE,
+					'title'  => CKGF_SHORT_TITLE,
 					'fields' => array(
 						array(
 							'name' => 'ckgf_enable_creator_network_recommendations_description',
@@ -303,7 +303,7 @@ class GFConvertKit extends GFFeedAddOn {
 		// Return field to toggle the setting.
 		return array(
 			'ckgf' => array(
-				'title'  => CKGF_TITLE,
+				'title'  => CKGF_SHORT_TITLE,
 				'fields' => array(
 					array(
 						'name'    => 'ckgf_enable_creator_network_recommendations',
@@ -356,7 +356,7 @@ class GFConvertKit extends GFFeedAddOn {
 		}
 
 		// Enqueue script.
-		wp_enqueue_script( 'ckgf-creator-network-recommendations', $script_url, false, CKGF_PLUGIN_VERSION, true );
+		wp_enqueue_script( 'ckgf-creator-network-recommendations', $script_url, array(), CKGF_PLUGIN_VERSION, true );
 
 	}
 
@@ -1288,14 +1288,23 @@ class GFConvertKit extends GFFeedAddOn {
 		}
 
 		// No cached script; fetch from the API.
-		$api    = new CKGF_API(
+		$api = new CKGF_API(
 			$this->api_key(),
 			$this->api_secret(),
 			$this->debug_enabled()
 		);
+
+		// Sanity check that we're using the ConvertKit WordPress Libraries 1.3.7 or higher.
+		// If another ConvertKit Plugin is active and out of date, its libraries might
+		// be loaded that don't have this method.
+		if ( ! method_exists( $api, 'recommendations_script' ) ) {
+			return false;
+		}
+
+		// Get script from API.
 		$result = $api->recommendations_script();
 
-		// Bail if an error occured
+		// Bail if an error occured.
 		if ( is_wp_error( $result ) ) {
 			return $result;
 		}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -19,9 +19,8 @@ function ckgf_get_settings_link( $query_args = array() ) {
 	$query_args = array_merge(
 		$query_args,
 		array(
-			'page'    => 'wc-settings',
-			'tab'     => 'integration',
-			'section' => 'ckwc',
+			'page'    => 'gf_settings',
+			'subview' => 'ckgf',
 		)
 	);
 
@@ -65,5 +64,18 @@ function ckgf_get_signup_url() {
 function ckgf_get_api_key_url() {
 
 	return 'https://app.convertkit.com/account_settings/advanced_settings/?utm_source=wordpress&utm_content=convertkit-gravity-forms';
+
+}
+
+/**
+ * Helper method to return the URL the user needs to visit on the ConvertKit app to upgrade their account.
+ *
+ * @since   1.3.7
+ *
+ * @return  string  ConvertKit App URL.
+ */
+function ckgf_get_settings_billing_url() {
+
+    return 'https://app.convertkit.com/account_settings/billing/?utm_source=wordpress&utm_content=convertkit-gravity-forms';
 
 }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -76,6 +76,6 @@ function ckgf_get_api_key_url() {
  */
 function ckgf_get_settings_billing_url() {
 
-    return 'https://app.convertkit.com/account_settings/billing/?utm_source=wordpress&utm_content=convertkit-gravity-forms';
+	return 'https://app.convertkit.com/account_settings/billing/?utm_source=wordpress&utm_content=convertkit-gravity-forms';
 
 }

--- a/tests/_support/Helper/Acceptance/GravityForms.php
+++ b/tests/_support/Helper/Acceptance/GravityForms.php
@@ -240,9 +240,10 @@ class GravityForms extends \Codeception\Module
 	 *
 	 * @param   AcceptanceTester $I              AcceptanceTester.
 	 * @param   int              $gravityFormID  Gravity Forms Form ID.
+	 * @param 	bool 			 $ajax 			 Enable AJAX on Form Submission.
 	 * @return  int                                 Page ID
 	 */
-	public function createPageWithGravityFormShortcode($I, $gravityFormID)
+	public function createPageWithGravityFormShortcode($I, $gravityFormID, $ajax = false)
 	{
 		return $I->havePostInDatabase(
 			[
@@ -250,7 +251,7 @@ class GravityForms extends \Codeception\Module
 				'post_status'  => 'publish',
 				'post_name'    => 'gravity-form-' . $gravityFormID,
 				'post_title'   => 'Gravity Form #' . $gravityFormID,
-				'post_content' => '[gravityform id="' . $gravityFormID . '" title="false" description="false"]',
+				'post_content' => '[gravityform id="' . $gravityFormID . '" title="false" description="false" ajax="' . ( $ajax ? 'true' : 'false' ) . '"]',
 			]
 		);
 	}

--- a/tests/_support/Helper/Acceptance/GravityForms.php
+++ b/tests/_support/Helper/Acceptance/GravityForms.php
@@ -10,6 +10,82 @@ namespace Helper\Acceptance;
 class GravityForms extends \Codeception\Module
 {
 	/**
+	 * Enables HTML5 Output in Gravity Forms.
+	 *
+	 * @since   1.3.7
+	 *
+	 * @param   AcceptanceTester $I     AcceptanceTester.
+	 */
+	public function enableGravityFormsHTML5Output($I)
+	{
+		$I->haveOptionInDatabase('rg_gforms_enable_html5', '1');
+	}
+
+	/**
+	 * Disables HTML5 Output in Gravity Forms.
+	 *
+	 * @since   1.3.7
+	 *
+	 * @param   AcceptanceTester $I     AcceptanceTester.
+	 */
+	public function disableGravityFormsHTML5Output($I)
+	{
+		$I->haveOptionInDatabase('rg_gforms_enable_html5', '0');
+	}
+
+	/**
+	 * Check that the Form Settings screen for the given Gravity Form has a ConvertKit
+	 * section registered, displaying the given message.
+	 *
+	 * @since   1.3.7
+	 *
+	 * @param   AcceptanceTester $I                 AcceptanceTester.
+	 * @param   int              $gravityFormID     Gravity Forms Form ID.
+	 * @param   string           $message           Message.
+	 */
+	public function seeGravityFormsSettingMessage($I, $gravityFormID, $message)
+	{
+		// Navigate to Form's settings.
+		$I->amOnAdminPage('admin.php?page=gf_edit_forms&view=settings&subview=settings&id=' . $gravityFormID);
+
+		// Confirm the ConvertKit settings section exists.
+		$I->seeElementInDOM('#gform-settings-section-convertkit');
+
+		// Confirm a message is displayed telling the user HTML5 output is required.
+		$I->seeInSource($message);
+	}
+
+	/**
+	 * Check that enabling the Creator Network Recommendations on the Form Settings screen
+	 * for the given Gravity Form works.
+	 *
+	 * @since   1.3.7
+	 *
+	 * @param   AcceptanceTester $I                 AcceptanceTester.
+	 * @param   int              $gravityFormID     Gravity Forms Form ID.
+	 */
+	public function enableGravityFormsSettingCreatorNetworkRecommendations($I, $gravityFormID)
+	{
+		// Navigate to Form's settings.
+		$I->amOnAdminPage('admin.php?page=gf_edit_forms&view=settings&subview=settings&id=' . $gravityFormID);
+
+		// Confirm the ConvertKit settings section exists.
+		$I->seeElementInDOM('#gform-settings-section-convertkit');
+
+		// Enable Creator Network Recommendations.
+		$I->click('label[for="_gform_setting_ckgf_enable_creator_network_recommendations"]');
+
+		// Save settings.
+		$I->click('#gform-settings-save');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm settings saved.
+		$I->seeCheckboxIsChecked('#_gform_setting_ckgf_enable_creator_network_recommendations');
+	}
+
+	/**
 	 * Creates a Gravity Forms Form.
 	 *
 	 * @since   1.2.1
@@ -240,7 +316,7 @@ class GravityForms extends \Codeception\Module
 	 *
 	 * @param   AcceptanceTester $I              AcceptanceTester.
 	 * @param   int              $gravityFormID  Gravity Forms Form ID.
-	 * @param 	bool 			 $ajax 			 Enable AJAX on Form Submission.
+	 * @param   bool             $ajax           Enable AJAX on Form Submission.
 	 * @return  int                                 Page ID
 	 */
 	public function createPageWithGravityFormShortcode($I, $gravityFormID, $ajax = false)

--- a/tests/_support/Helper/Acceptance/Plugin.php
+++ b/tests/_support/Helper/Acceptance/Plugin.php
@@ -185,6 +185,48 @@ class Plugin extends \Codeception\Module
 	}
 
 	/**
+	 * Check that the given Page does output the Creator Network Recommendations
+	 * script.
+	 *
+	 * @since   1.3.7
+	 *
+	 * @param   AcceptanceTester $I             AcceptanceTester.
+	 * @param   int              $pageID        Page ID.
+	 */
+	public function seeCreatorNetworkRecommendationsScript($I, $pageID)
+	{
+		// Load the Page on the frontend site.
+		$I->amOnPage('/?p=' . $pageID);
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm the recommendations script was not loaded.
+		$I->seeInSource('recommendations.js');
+	}
+
+	/**
+	 * Check that the given Page does not output the Creator Network Recommendations
+	 * script.
+	 *
+	 * @since   1.3.7
+	 *
+	 * @param   AcceptanceTester $I             AcceptanceTester.
+	 * @param   int              $pageID        Page ID.
+	 */
+	public function dontSeeCreatorNetworkRecommendationsScript($I, $pageID)
+	{
+		// Load the Page on the frontend site.
+		$I->amOnPage('/?p=' . $pageID);
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm the recommendations script was not loaded.
+		$I->dontSeeInSource('recommendations.js');
+	}
+
+	/**
 	 * Helper method to reset the ConvertKit Plugin settings, as if it's a clean installation.
 	 *
 	 * @since   1.2.2

--- a/tests/acceptance/recommendations/RecommendationsCest.php
+++ b/tests/acceptance/recommendations/RecommendationsCest.php
@@ -17,7 +17,6 @@ class RecommendationsCest
 	{
 		$I->activateConvertKitPlugin($I);
 		$I->activateThirdPartyPlugin($I, 'gravity-forms');
-		$I->setupConvertKitPlugin($I);
 	}
 
 	/**
@@ -30,7 +29,32 @@ class RecommendationsCest
 	 */
 	public function testCreatorNetworkRecommendationsOptionWhenOutputHTML5Disabled(AcceptanceTester $I)
 	{
+		// Disable Output HTML5 option.
+		$I->haveOptionInDatabase('rg_gforms_enable_html5', '0');
 
+		// Create Form.
+		$gravityFormID = $I->createGravityFormsForm($I);
+
+		// Navigate to Form's settings.
+		$I->amOnAdminPage('admin.php?page=gf_edit_forms&view=settings&subview=settings&id=' . $gravityFormID);
+
+		// Confirm the ConvertKit settings section exists.
+		$I->seeElementInDOM('#gform-settings-section-convertkit');
+
+		// Confirm a message is displayed telling the user HTML5 output is required.
+		$I->seeInSource('HTML5 output is required for proper function. Please enable this in  <a href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-admin/admin.php?page=gf_settings">Gravity Forms settings.</a>');
+
+		// Create a Page with the Gravity Forms shortcode as its content.
+		$pageID = $I->createPageWithGravityFormShortcode($I, $gravityFormID);
+
+		// Load the Page on the frontend site.
+		$I->amOnPage('/?p=' . $pageID);
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm the recommendations script was not loaded.
+		$I->dontSeeInSource('recommendations.js');
 	}
 
 	/**
@@ -41,9 +65,74 @@ class RecommendationsCest
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
-	public function testCreatorNetworkRecommendationsOptionWhenNoAPICredentials(AcceptanceTester $I)
+	public function testCreatorNetworkRecommendationsOptionWhenNoAPIKeyOrSecret(AcceptanceTester $I)
 	{
+		// Enable Output HTML5 option.
+		$I->haveOptionInDatabase('rg_gforms_enable_html5', '1');
 
+		// Create Form.
+		$gravityFormID = $I->createGravityFormsForm($I);
+
+		// Navigate to Form's settings.
+		$I->amOnAdminPage('admin.php?page=gf_edit_forms&view=settings&subview=settings&id=' . $gravityFormID);
+
+		// Confirm the ConvertKit settings section exists.
+		$I->seeElementInDOM('#gform-settings-section-convertkit');
+
+		// Confirm a message is displayed telling the user to enter their API Key and Secret.
+		$I->seeInSource('Please enter your API Key and Secret on the <a href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-admin/admin.php?page=gf_settings&amp;subview=ckgf">settings screen</a>');
+
+		// Create a Page with the Gravity Forms shortcode as its content.
+		$pageID = $I->createPageWithGravityFormShortcode($I, $gravityFormID);
+
+		// Load the Page on the frontend site.
+		$I->amOnPage('/?p=' . $pageID);
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm the recommendations script was not loaded.
+		$I->dontSeeInSource('recommendations.js');
+	}
+
+	/**
+	 * Tests that the 'Enable Creator Network Recommendations' option on a Form's settings
+	 * is not displayed when no API Secret is specified at Forms > Settings > ConvertKit.
+	 * 
+	 * This handles users upgrading from < 1.3.7, where no API Secret setting was provided.
+	 *
+	 * @since   1.3.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testCreatorNetworkRecommendationsOptionWhenNoAPISecret(AcceptanceTester $I)
+	{
+		// Enable Output HTML5 option.
+		$I->haveOptionInDatabase('rg_gforms_enable_html5', '1');
+
+		// Create Form.
+		$gravityFormID = $I->createGravityFormsForm($I);
+
+		// Navigate to Form's settings.
+		$I->amOnAdminPage('admin.php?page=gf_edit_forms&view=settings&subview=settings&id=' . $gravityFormID);
+
+		// Confirm the ConvertKit settings section exists.
+		$I->seeElementInDOM('#gform-settings-section-convertkit');
+
+		// Confirm a message is displayed telling the user to enter their API Key and Secret.
+		$I->seeInSource('Please enter your API Key and Secret on the <a href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-admin/admin.php?page=gf_settings&amp;subview=ckgf">settings screen</a>');
+
+		// Create a Page with the Gravity Forms shortcode as its content.
+		$pageID = $I->createPageWithGravityFormShortcode($I, $gravityFormID);
+
+		// Load the Page on the frontend site.
+		$I->amOnPage('/?p=' . $pageID);
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm the recommendations script was not loaded.
+		$I->dontSeeInSource('recommendations.js');
 	}
 
 	/**
@@ -56,7 +145,35 @@ class RecommendationsCest
 	 */
 	public function testCreatorNetworkRecommendationsOptionWhenInvalidAPICredentials(AcceptanceTester $I)
 	{
+		// Enable Output HTML5 option.
+		$I->haveOptionInDatabase('rg_gforms_enable_html5', '1');
 
+		// Define invalid API Credentials.
+
+
+		// Create Form.
+		$gravityFormID = $I->createGravityFormsForm($I);
+
+		// Navigate to Form's settings.
+		$I->amOnAdminPage('admin.php?page=gf_edit_forms&view=settings&subview=settings&id=' . $gravityFormID);
+
+		// Confirm the ConvertKit settings section exists.
+		$I->seeElementInDOM('#gform-settings-section-convertkit');
+
+		// Confirm a message is displayed telling the user to enter their API Key and Secret.
+		$I->seeInSource('Please enter your API Key and Secret on the <a href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-admin/admin.php?page=gf_settings&amp;subview=ckgf">settings screen</a>');
+
+		// Create a Page with the Gravity Forms shortcode as its content.
+		$pageID = $I->createPageWithGravityFormShortcode($I, $gravityFormID);
+
+		// Load the Page on the frontend site.
+		$I->amOnPage('/?p=' . $pageID);
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm the recommendations script was not loaded.
+		$I->dontSeeInSource('recommendations.js');
 	}
 
 	/**

--- a/tests/acceptance/recommendations/RecommendationsCest.php
+++ b/tests/acceptance/recommendations/RecommendationsCest.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * Tests that the Creator Network Recommendations settings work with a Gravity Form
+ *
+ * @since   1.3.7
+ */
+class RecommendationsCest
+{
+	/**
+	 * Run common actions before running the test functions in this class.
+	 *
+	 * @since   1.3.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function _before(AcceptanceTester $I)
+	{
+		$I->activateConvertKitPlugin($I);
+		$I->activateThirdPartyPlugin($I, 'gravity-forms');
+		$I->setupConvertKitPlugin($I);
+	}
+
+	/**
+	 * Tests that the 'Enable Creator Network Recommendations' option on a Form's settings
+	 * is not displayed when Gravity Forms 'Output HTML5' is disabled.
+	 *
+	 * @since   1.3.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testCreatorNetworkRecommendationsOptionWhenOutputHTML5Disabled(AcceptanceTester $I)
+	{
+
+	}
+
+	/**
+	 * Tests that the 'Enable Creator Network Recommendations' option on a Form's settings
+	 * is not displayed when no API Credentials are specified at Forms > Settings > ConvertKit.
+	 *
+	 * @since   1.3.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testCreatorNetworkRecommendationsOptionWhenNoAPICredentials(AcceptanceTester $I)
+	{
+
+	}
+
+	/**
+	 * Tests that the 'Enable Creator Network Recommendations' option on a Form's settings
+	 * is not displayed when invalid API Credentials are specified at Forms > Settings > ConvertKit.
+	 *
+	 * @since   1.3.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testCreatorNetworkRecommendationsOptionWhenInvalidAPICredentials(AcceptanceTester $I)
+	{
+
+	}
+
+	/**
+	 * Tests that the 'Enable Creator Network Recommendations' option on a Form's settings
+	 * is not displayed when valid API Credentials are specified at Forms > Settings > ConvertKit,
+	 * but the ConvertKit account does not have the Creator Network enabled.
+	 *
+	 * @since   1.3.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testCreatorNetworkRecommendationsOptionWhenDisabledOnConvertKitAccount(AcceptanceTester $I)
+	{
+
+	}
+
+	/**
+	 * Tests that the 'Enable Creator Network Recommendations' option on a Form's settings
+	 * is displayed and saves correctly when valid API Credentials are specified at Forms > Settings > ConvertKit,
+	 * and the ConvertKit account has the Creator Network enabled.
+	 *
+	 * @since   1.3.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testCreatorNetworkRecommendations(AcceptanceTester $I)
+	{
+
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 *
+	 * @since   1.3.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->deactivateConvertKitPlugin($I);
+		$I->deactivateThirdPartyPlugin($I, 'gravity-forms');
+		$I->resetConvertKitPlugin($I);
+	}
+}

--- a/tests/acceptance/recommendations/RecommendationsCest.php
+++ b/tests/acceptance/recommendations/RecommendationsCest.php
@@ -30,31 +30,23 @@ class RecommendationsCest
 	public function testCreatorNetworkRecommendationsOptionWhenOutputHTML5Disabled(AcceptanceTester $I)
 	{
 		// Disable Output HTML5 option.
-		$I->haveOptionInDatabase('rg_gforms_enable_html5', '0');
+		$I->disableGravityFormsHTML5Output($I);
 
 		// Create Form.
 		$gravityFormID = $I->createGravityFormsForm($I);
 
-		// Navigate to Form's settings.
-		$I->amOnAdminPage('admin.php?page=gf_edit_forms&view=settings&subview=settings&id=' . $gravityFormID);
-
-		// Confirm the ConvertKit settings section exists.
-		$I->seeElementInDOM('#gform-settings-section-convertkit');
-
-		// Confirm a message is displayed telling the user HTML5 output is required.
-		$I->seeInSource('HTML5 output is required for proper function. Please enable this in  <a href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-admin/admin.php?page=gf_settings">Gravity Forms settings.</a>');
+		// Confirm that the Form Settings display the expected error message.
+		$I->seeGravityFormsSettingMessage(
+			$I,
+			$gravityFormID,
+			'HTML5 output is required for proper function. Please enable this in  <a href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-admin/admin.php?page=gf_settings">Gravity Forms settings.</a>'
+		);
 
 		// Create a Page with the Gravity Forms shortcode as its content.
 		$pageID = $I->createPageWithGravityFormShortcode($I, $gravityFormID);
 
-		// Load the Page on the frontend site.
-		$I->amOnPage('/?p=' . $pageID);
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-
 		// Confirm the recommendations script was not loaded.
-		$I->dontSeeInSource('recommendations.js');
+		$I->dontSeeCreatorNetworkRecommendationsScript($I, $pageID);
 	}
 
 	/**
@@ -68,37 +60,29 @@ class RecommendationsCest
 	public function testCreatorNetworkRecommendationsOptionWhenNoAPIKeyOrSecret(AcceptanceTester $I)
 	{
 		// Enable Output HTML5 option.
-		$I->haveOptionInDatabase('rg_gforms_enable_html5', '1');
+		$I->enableGravityFormsHTML5Output($I);
 
 		// Create Form.
 		$gravityFormID = $I->createGravityFormsForm($I);
 
-		// Navigate to Form's settings.
-		$I->amOnAdminPage('admin.php?page=gf_edit_forms&view=settings&subview=settings&id=' . $gravityFormID);
-
-		// Confirm the ConvertKit settings section exists.
-		$I->seeElementInDOM('#gform-settings-section-convertkit');
-
-		// Confirm a message is displayed telling the user to enter their API Key and Secret.
-		$I->seeInSource('Please enter your API Key and Secret on the <a href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-admin/admin.php?page=gf_settings&amp;subview=ckgf">settings screen</a>');
+		// Confirm that the Form Settings display the expected error message.
+		$I->seeGravityFormsSettingMessage(
+			$I,
+			$gravityFormID,
+			'Please enter your API Key and Secret on the <a href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-admin/admin.php?page=gf_settings&amp;subview=ckgf">settings screen</a>'
+		);
 
 		// Create a Page with the Gravity Forms shortcode as its content.
 		$pageID = $I->createPageWithGravityFormShortcode($I, $gravityFormID);
 
-		// Load the Page on the frontend site.
-		$I->amOnPage('/?p=' . $pageID);
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-
 		// Confirm the recommendations script was not loaded.
-		$I->dontSeeInSource('recommendations.js');
+		$I->dontSeeCreatorNetworkRecommendationsScript($I, $pageID);
 	}
 
 	/**
 	 * Tests that the 'Enable Creator Network Recommendations' option on a Form's settings
 	 * is not displayed when no API Secret is specified at Forms > Settings > ConvertKit.
-	 * 
+	 *
 	 * This handles users upgrading from < 1.3.7, where no API Secret setting was provided.
 	 *
 	 * @since   1.3.7
@@ -111,31 +95,23 @@ class RecommendationsCest
 		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY'], '', false);
 
 		// Enable Output HTML5 option.
-		$I->haveOptionInDatabase('rg_gforms_enable_html5', '1');
+		$I->enableGravityFormsHTML5Output($I);
 
 		// Create Form.
 		$gravityFormID = $I->createGravityFormsForm($I);
 
-		// Navigate to Form's settings.
-		$I->amOnAdminPage('admin.php?page=gf_edit_forms&view=settings&subview=settings&id=' . $gravityFormID);
-
-		// Confirm the ConvertKit settings section exists.
-		$I->seeElementInDOM('#gform-settings-section-convertkit');
-
-		// Confirm a message is displayed telling the user to enter their API Key and Secret.
-		$I->seeInSource('Please enter your API Key and Secret on the <a href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-admin/admin.php?page=gf_settings&amp;subview=ckgf">settings screen</a>');
+		// Confirm that the Form Settings display the expected error message.
+		$I->seeGravityFormsSettingMessage(
+			$I,
+			$gravityFormID,
+			'Please enter your API Key and Secret on the <a href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-admin/admin.php?page=gf_settings&amp;subview=ckgf">settings screen</a>'
+		);
 
 		// Create a Page with the Gravity Forms shortcode as its content.
 		$pageID = $I->createPageWithGravityFormShortcode($I, $gravityFormID);
 
-		// Load the Page on the frontend site.
-		$I->amOnPage('/?p=' . $pageID);
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-
 		// Confirm the recommendations script was not loaded.
-		$I->dontSeeInSource('recommendations.js');
+		$I->dontSeeCreatorNetworkRecommendationsScript($I, $pageID);
 	}
 
 	/**
@@ -152,31 +128,23 @@ class RecommendationsCest
 		$I->setupConvertKitPlugin($I, 'fakeApiKey', 'fakeApiSecret');
 
 		// Enable Output HTML5 option.
-		$I->haveOptionInDatabase('rg_gforms_enable_html5', '1');
+		$I->enableGravityFormsHTML5Output($I);
 
 		// Create Form.
 		$gravityFormID = $I->createGravityFormsForm($I);
 
-		// Navigate to Form's settings.
-		$I->amOnAdminPage('admin.php?page=gf_edit_forms&view=settings&subview=settings&id=' . $gravityFormID);
-
-		// Confirm the ConvertKit settings section exists.
-		$I->seeElementInDOM('#gform-settings-section-convertkit');
-
-		// Confirm a message is displayed telling the user that their API Secret is not valid.
-		$I->seeInSource('Authorization Failed: API Secret not valid. <a href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-admin/admin.php?page=gf_settings&amp;subview=ckgf">Fix settings</a>');
+		// Confirm that the Form Settings display the expected error message.
+		$I->seeGravityFormsSettingMessage(
+			$I,
+			$gravityFormID,
+			'Authorization Failed: API Secret not valid. <a href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-admin/admin.php?page=gf_settings&amp;subview=ckgf">Fix settings</a>'
+		);
 
 		// Create a Page with the Gravity Forms shortcode as its content.
 		$pageID = $I->createPageWithGravityFormShortcode($I, $gravityFormID);
 
-		// Load the Page on the frontend site.
-		$I->amOnPage('/?p=' . $pageID);
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-
 		// Confirm the recommendations script was not loaded.
-		$I->dontSeeInSource('recommendations.js');
+		$I->dontSeeCreatorNetworkRecommendationsScript($I, $pageID);
 	}
 
 	/**
@@ -194,31 +162,23 @@ class RecommendationsCest
 		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY_NO_DATA'], $_ENV['CONVERTKIT_API_SECRET_NO_DATA']);
 
 		// Enable Output HTML5 option.
-		$I->haveOptionInDatabase('rg_gforms_enable_html5', '1');
+		$I->enableGravityFormsHTML5Output($I);
 
 		// Create Form.
 		$gravityFormID = $I->createGravityFormsForm($I);
 
-		// Navigate to Form's settings.
-		$I->amOnAdminPage('admin.php?page=gf_edit_forms&view=settings&subview=settings&id=' . $gravityFormID);
-
-		// Confirm the ConvertKit settings section exists.
-		$I->seeElementInDOM('#gform-settings-section-convertkit');
-
-		// Confirm a message is displayed telling the user that their API Secret is not valid.
-		$I->seeInSource('Creator Network Recommendations requires a <a href="https://app.convertkit.com/account_settings/billing/?utm_source=wordpress&amp;utm_content=convertkit-gravity-forms">paid ConvertKit Plan</a>');
+		// Confirm that the Form Settings display the expected error message.
+		$I->seeGravityFormsSettingMessage(
+			$I,
+			$gravityFormID,
+			'Creator Network Recommendations requires a <a href="https://app.convertkit.com/account_settings/billing/?utm_source=wordpress&amp;utm_content=convertkit-gravity-forms">paid ConvertKit Plan</a>'
+		);
 
 		// Create a Page with the Gravity Forms shortcode as its content.
 		$pageID = $I->createPageWithGravityFormShortcode($I, $gravityFormID);
 
-		// Load the Page on the frontend site.
-		$I->amOnPage('/?p=' . $pageID);
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-
 		// Confirm the recommendations script was not loaded.
-		$I->dontSeeInSource('recommendations.js');
+		$I->dontSeeCreatorNetworkRecommendationsScript($I, $pageID);
 	}
 
 	/**
@@ -238,41 +198,19 @@ class RecommendationsCest
 		$I->setupConvertKitPlugin($I);
 
 		// Enable Output HTML5 option.
-		$I->haveOptionInDatabase('rg_gforms_enable_html5', '1');
+		$I->enableGravityFormsHTML5Output($I);
 
 		// Create Form.
 		$gravityFormID = $I->createGravityFormsForm($I);
 
-		// Navigate to Form's settings.
-		$I->amOnAdminPage('admin.php?page=gf_edit_forms&view=settings&subview=settings&id=' . $gravityFormID);
+		// Enable Creator Network Recommendations on the form's settings.
+		$I->enableGravityFormsSettingCreatorNetworkRecommendations($I, $gravityFormID);
 
-		// Confirm the ConvertKit settings section exists.
-		$I->seeElementInDOM('#gform-settings-section-convertkit');
-
-		// Enable Creator Network Recommendations.
-		$I->click('label[for="_gform_setting_ckgf_enable_creator_network_recommendations"]');
-
-		// Save settings.
-		$I->click('#gform-settings-save');
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-
-		// Confirm settings saved.
-		$I->seeCheckboxIsChecked('#_gform_setting_ckgf_enable_creator_network_recommendations');
-		
 		// Create a Page with the Gravity Forms shortcode as its content.
 		$pageID = $I->createPageWithGravityFormShortcode($I, $gravityFormID);
 
-		// Load the Page on the frontend site.
-		$I->amOnPage('/?p=' . $pageID);
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-
-		// Confirm the recommendations script was not loaded, because the form's AJAX submission
-		// option is disabled.
-		$I->dontSeeInSource('recommendations.js');
+		// Confirm the recommendations script was not loaded, because AJAX was disabled on the form.
+		$I->dontSeeCreatorNetworkRecommendationsScript($I, $pageID);
 	}
 
 	/**
@@ -291,40 +229,19 @@ class RecommendationsCest
 		$I->setupConvertKitPlugin($I);
 
 		// Enable Output HTML5 option.
-		$I->haveOptionInDatabase('rg_gforms_enable_html5', '1');
+		$I->enableGravityFormsHTML5Output($I);
 
 		// Create Form.
 		$gravityFormID = $I->createGravityFormsForm($I);
 
-		// Navigate to Form's settings.
-		$I->amOnAdminPage('admin.php?page=gf_edit_forms&view=settings&subview=settings&id=' . $gravityFormID);
+		// Enable Creator Network Recommendations on the form's settings.
+		$I->enableGravityFormsSettingCreatorNetworkRecommendations($I, $gravityFormID);
 
-		// Confirm the ConvertKit settings section exists.
-		$I->seeElementInDOM('#gform-settings-section-convertkit');
-
-		// Enable Creator Network Recommendations.
-		$I->click('label[for="_gform_setting_ckgf_enable_creator_network_recommendations"]');
-
-		// Save settings.
-		$I->click('#gform-settings-save');
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-
-		// Confirm settings saved.
-		$I->seeCheckboxIsChecked('#_gform_setting_ckgf_enable_creator_network_recommendations');
-		
 		// Create a Page with the Gravity Forms shortcode as its content.
 		$pageID = $I->createPageWithGravityFormShortcode($I, $gravityFormID, true);
 
-		// Load the Page on the frontend site.
-		$I->amOnPage('/?p=' . $pageID);
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-
 		// Confirm the recommendations script was loaded.
-		$I->seeInSource('recommendations.js');
+		$I->seeCreatorNetworkRecommendationsScript($I, $pageID);
 
 		// Complete Form Fields.
 		$I->fillField('.name_first input[type=text]', 'First');

--- a/tests/acceptance/recommendations/RecommendationsCest.php
+++ b/tests/acceptance/recommendations/RecommendationsCest.php
@@ -59,7 +59,7 @@ class RecommendationsCest
 
 	/**
 	 * Tests that the 'Enable Creator Network Recommendations' option on a Form's settings
-	 * is not displayed when no API Credentials are specified at Forms > Settings > ConvertKit.
+	 * is not displayed when no API Key and Secret are specified at Forms > Settings > ConvertKit.
 	 *
 	 * @since   1.3.7
 	 *
@@ -107,6 +107,9 @@ class RecommendationsCest
 	 */
 	public function testCreatorNetworkRecommendationsOptionWhenNoAPISecret(AcceptanceTester $I)
 	{
+		// Setup Plugin with just the API Key, as if we're upgrading from < 1.3.7.
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY'], '', false);
+
 		// Enable Output HTML5 option.
 		$I->haveOptionInDatabase('rg_gforms_enable_html5', '1');
 
@@ -137,19 +140,19 @@ class RecommendationsCest
 
 	/**
 	 * Tests that the 'Enable Creator Network Recommendations' option on a Form's settings
-	 * is not displayed when invalid API Credentials are specified at Forms > Settings > ConvertKit.
+	 * is not displayed when invalid API Key and Secret are specified at Forms > Settings > ConvertKit.
 	 *
 	 * @since   1.3.7
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
-	public function testCreatorNetworkRecommendationsOptionWhenInvalidAPICredentials(AcceptanceTester $I)
+	public function testCreatorNetworkRecommendationsOptionWhenInvalidAPIKeyAndSecret(AcceptanceTester $I)
 	{
+		// Setup Plugin with invalid API Key and Secret.
+		$I->setupConvertKitPlugin($I, 'fakeApiKey', 'fakeApiSecret');
+
 		// Enable Output HTML5 option.
 		$I->haveOptionInDatabase('rg_gforms_enable_html5', '1');
-
-		// Define invalid API Credentials.
-
 
 		// Create Form.
 		$gravityFormID = $I->createGravityFormsForm($I);
@@ -160,8 +163,8 @@ class RecommendationsCest
 		// Confirm the ConvertKit settings section exists.
 		$I->seeElementInDOM('#gform-settings-section-convertkit');
 
-		// Confirm a message is displayed telling the user to enter their API Key and Secret.
-		$I->seeInSource('Please enter your API Key and Secret on the <a href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-admin/admin.php?page=gf_settings&amp;subview=ckgf">settings screen</a>');
+		// Confirm a message is displayed telling the user that their API Secret is not valid.
+		$I->seeInSource('Authorization Failed: API Secret not valid. <a href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-admin/admin.php?page=gf_settings&amp;subview=ckgf">Fix settings</a>');
 
 		// Create a Page with the Gravity Forms shortcode as its content.
 		$pageID = $I->createPageWithGravityFormShortcode($I, $gravityFormID);
@@ -178,7 +181,7 @@ class RecommendationsCest
 
 	/**
 	 * Tests that the 'Enable Creator Network Recommendations' option on a Form's settings
-	 * is not displayed when valid API Credentials are specified at Forms > Settings > ConvertKit,
+	 * is not displayed when valid API Key and Secret are specified at Forms > Settings > ConvertKit,
 	 * but the ConvertKit account does not have the Creator Network enabled.
 	 *
 	 * @since   1.3.7
@@ -187,21 +190,163 @@ class RecommendationsCest
 	 */
 	public function testCreatorNetworkRecommendationsOptionWhenDisabledOnConvertKitAccount(AcceptanceTester $I)
 	{
+		// Setup Plugin with API Key and Secret for ConvertKit Account that does not have the Creator Network enabled.
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY_NO_DATA'], $_ENV['CONVERTKIT_API_SECRET_NO_DATA']);
 
+		// Enable Output HTML5 option.
+		$I->haveOptionInDatabase('rg_gforms_enable_html5', '1');
+
+		// Create Form.
+		$gravityFormID = $I->createGravityFormsForm($I);
+
+		// Navigate to Form's settings.
+		$I->amOnAdminPage('admin.php?page=gf_edit_forms&view=settings&subview=settings&id=' . $gravityFormID);
+
+		// Confirm the ConvertKit settings section exists.
+		$I->seeElementInDOM('#gform-settings-section-convertkit');
+
+		// Confirm a message is displayed telling the user that their API Secret is not valid.
+		$I->seeInSource('Creator Network Recommendations requires a <a href="https://app.convertkit.com/account_settings/billing/?utm_source=wordpress&amp;utm_content=convertkit-gravity-forms">paid ConvertKit Plan</a>');
+
+		// Create a Page with the Gravity Forms shortcode as its content.
+		$pageID = $I->createPageWithGravityFormShortcode($I, $gravityFormID);
+
+		// Load the Page on the frontend site.
+		$I->amOnPage('/?p=' . $pageID);
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm the recommendations script was not loaded.
+		$I->dontSeeInSource('recommendations.js');
 	}
 
 	/**
 	 * Tests that the 'Enable Creator Network Recommendations' option on a Form's settings
-	 * is displayed and saves correctly when valid API Credentials are specified at Forms > Settings > ConvertKit,
-	 * and the ConvertKit account has the Creator Network enabled.
+	 * is displayed and saves correctly when valid API Key and Secret are specified at Forms > Settings > ConvertKit,
+	 * and the ConvertKit account has the Creator Network enabled.  Viewing and submitting the Form does not
+	 * display the Creator Network Recommendations modal, because the form submission will reload the page,
+	 * which isn't supported right now.
 	 *
 	 * @since   1.3.7
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
-	public function testCreatorNetworkRecommendations(AcceptanceTester $I)
+	public function testCreatorNetworkRecommendationsWithAJAXDisabled(AcceptanceTester $I)
 	{
+		// Setup Plugin.
+		$I->setupConvertKitPlugin($I);
 
+		// Enable Output HTML5 option.
+		$I->haveOptionInDatabase('rg_gforms_enable_html5', '1');
+
+		// Create Form.
+		$gravityFormID = $I->createGravityFormsForm($I);
+
+		// Navigate to Form's settings.
+		$I->amOnAdminPage('admin.php?page=gf_edit_forms&view=settings&subview=settings&id=' . $gravityFormID);
+
+		// Confirm the ConvertKit settings section exists.
+		$I->seeElementInDOM('#gform-settings-section-convertkit');
+
+		// Enable Creator Network Recommendations.
+		$I->click('label[for="_gform_setting_ckgf_enable_creator_network_recommendations"]');
+
+		// Save settings.
+		$I->click('#gform-settings-save');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm settings saved.
+		$I->seeCheckboxIsChecked('#_gform_setting_ckgf_enable_creator_network_recommendations');
+		
+		// Create a Page with the Gravity Forms shortcode as its content.
+		$pageID = $I->createPageWithGravityFormShortcode($I, $gravityFormID);
+
+		// Load the Page on the frontend site.
+		$I->amOnPage('/?p=' . $pageID);
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm the recommendations script was not loaded, because the form's AJAX submission
+		// option is disabled.
+		$I->dontSeeInSource('recommendations.js');
+	}
+
+	/**
+	 * Tests that the 'Enable Creator Network Recommendations' option on a Form's settings
+	 * is displayed and saves correctly when valid API Key and Secret are specified at Forms > Settings > ConvertKit,
+	 * and the ConvertKit account has the Creator Network enabled.  Viewing and submitting the Form then correctly
+	 * displays the Creator Network Recommendations modal.
+	 *
+	 * @since   1.3.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testCreatorNetworkRecommendationsWithAJAXEnabled(AcceptanceTester $I)
+	{
+		// Setup Plugin.
+		$I->setupConvertKitPlugin($I);
+
+		// Enable Output HTML5 option.
+		$I->haveOptionInDatabase('rg_gforms_enable_html5', '1');
+
+		// Create Form.
+		$gravityFormID = $I->createGravityFormsForm($I);
+
+		// Navigate to Form's settings.
+		$I->amOnAdminPage('admin.php?page=gf_edit_forms&view=settings&subview=settings&id=' . $gravityFormID);
+
+		// Confirm the ConvertKit settings section exists.
+		$I->seeElementInDOM('#gform-settings-section-convertkit');
+
+		// Enable Creator Network Recommendations.
+		$I->click('label[for="_gform_setting_ckgf_enable_creator_network_recommendations"]');
+
+		// Save settings.
+		$I->click('#gform-settings-save');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm settings saved.
+		$I->seeCheckboxIsChecked('#_gform_setting_ckgf_enable_creator_network_recommendations');
+		
+		// Create a Page with the Gravity Forms shortcode as its content.
+		$pageID = $I->createPageWithGravityFormShortcode($I, $gravityFormID, true);
+
+		// Load the Page on the frontend site.
+		$I->amOnPage('/?p=' . $pageID);
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm the recommendations script was loaded.
+		$I->seeInSource('recommendations.js');
+
+		// Complete Form Fields.
+		$I->fillField('.name_first input[type=text]', 'First');
+		$I->fillField('.name_last input[type=text]', 'Last');
+		$I->fillField('.ginput_container_email input[type=email]', $I->generateEmailAddress());
+
+		// Submit Form.
+		$I->click('Submit');
+
+		// Wait for Creator Network Recommendations modal to display.
+		$I->waitForElementVisible('.formkit-modal');
+		$I->switchToIFrame('.formkit-modal iframe');
+		$I->waitForElementVisible('div[data-component="Page"]');
+		$I->switchToIFrame();
+
+		// Close the modal.
+		$I->click('.formkit-modal button.formkit-close');
+
+		// Confirm that the underlying Gravity Form submitted successfully.
+		$I->waitForElementNotVisible('.formkit-modal');
+		$I->seeElementInDOM('.gform_confirmation_message');
+		$I->see('Thanks for contacting us! We will get in touch with you shortly.');
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Adds an option to enable the Creator Network Recommendations to a Gravity Forms Form:
![Screenshot 2023-07-14 at 13 55 13](https://github.com/ConvertKit/convertkit-gravity-forms/assets/1462305/e1fa1a57-cc27-4275-ad99-a82d9bfef7be)

When enabled, the modal is displayed when the form is submitted:
![Screenshot 2023-07-14 at 13 56 00](https://github.com/ConvertKit/convertkit-gravity-forms/assets/1462305/719e7103-063c-4eb7-925a-1e5095ca8839)

Demonstration:
https://www.loom.com/share/4d6667a987f6484a953fd6e6cce8fff6?sid=e50a65ac-30dd-432a-bc87-2a9f834e2622

Several requirements must be met for this to work:

### Output HTML5 must be enabled

`Output HTML5` must be enabled in Gravity Forms (Forms > Settings > Output HTML5).  This will output email fields as `input[type=email]`, which `recommendations.js` is compatible with.
![Screenshot 2023-07-14 at 13 54 42](https://github.com/ConvertKit/convertkit-gravity-forms/assets/1462305/37428699-c7ca-4b21-a0aa-2fb0ef4572c7)

If disabled, the form setting will tell the user what they need to do:
![Screenshot 2023-07-14 at 13 56 58](https://github.com/ConvertKit/convertkit-gravity-forms/assets/1462305/d6c6f94f-a593-49cd-bbd3-473332270f1b)

### Valid API Secret

A valid API Secret must be specified at `Forms > Settings > ConvertKit`.  1.3.6 and earlier of this Plugin only requested an API Key, but as the API endpoint to fetch the recommendations script requires an API Secret, this option was added in [this PR](https://github.com/ConvertKit/convertkit-gravity-forms/pull/90).

![Screenshot 2023-07-14 at 14 01 14](https://github.com/ConvertKit/convertkit-gravity-forms/assets/1462305/b1f77b80-cbdb-44a7-892f-522c7be9dd17)

### Creator Network Recommendations enabled

If the [API endpoint](https://github.com/ConvertKit/convertkit/pull/24419) `enabled` property returns `false`, the user is prompted to upgrade their ConvertKit Plan.

![Screenshot 2023-07-14 at 14 05 29](https://github.com/ConvertKit/convertkit-gravity-forms/assets/1462305/5c59edcd-4453-4914-b27e-8908de8fc995)

### AJAX Enabled on Form

When embedding the Gravity Forms Form into a WordPress Page, its AJAX setting must be enabled.

![Screenshot 2023-07-14 at 14 10 55](https://github.com/ConvertKit/convertkit-gravity-forms/assets/1462305/5c758b33-fa7f-4a10-99cb-7fa233d320fb)

If disabled, Gravity Forms will submit the form as a new request, reloading the page, meaning that the modal will not display.

## Testing

- `RecommendationsCest`: Added tests to cover above scenarios, ensuring the Creator Network Recommendations script is embedded if conditions are met.  When met, confirms the modal displays and can be closed.

## Checklist

* [x] I have [written a test](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)