### PR TITLE
Exclude `phpcs.tests.xml` from releases

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -25,6 +25,7 @@ DEVELOPMENT.md
 LICENSE
 log.txt
 phpcs.xml
+phpcs.tests.xml
 phpstan.neon
 phpstan.neon.dist
 phpstan.neon.example


### PR DESCRIPTION
## Summary

Excludes the `phpcs.tests.xml` file from [releases](https://github.com/ConvertKit/convertkit-gravity-forms/releases).

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)