### PR TITLE
Updated WordPress Libraries to 1.3.9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "license": "GPLv3",
     "require": {
-        "convertkit/convertkit-wordpress-libraries": "1.3.8"
+        "convertkit/convertkit-wordpress-libraries": "1.3.9"
     },
     "require-dev": {
         "lucatume/wp-browser": "^3.0",

--- a/includes/class-ckgf-api.php
+++ b/includes/class-ckgf-api.php
@@ -39,44 +39,6 @@ class CKGF_API extends ConvertKit_API {
 			$this->log = new ConvertKit_Log( $this->plugin_path );
 		}
 
-		// Define translatable / localized error strings.
-		// WordPress requires that the text domain be a string (e.g. 'convertkit') and not a variable,
-		// otherwise localization won't work.
-		$this->error_messages = array(
-			'form_subscribe_form_id_empty'                => __( 'form_subscribe(): the form_id parameter is empty.', 'convertkit' ),
-			'form_subscribe_email_empty'                  => __( 'form_subscribe(): the email parameter is empty.', 'convertkit' ),
-
-			'sequence_subscribe_sequence_id_empty'        => __( 'sequence_subscribe(): the sequence_id parameter is empty.', 'convertkit' ),
-			'sequence_subscribe_email_empty'              => __( 'sequence_subscribe(): the email parameter is empty.', 'convertkit' ),
-
-			'tag_subscribe_tag_id_empty'                  => __( 'tag_subscribe(): the tag_id parameter is empty.', 'convertkit' ),
-			'tag_subscribe_email_empty'                   => __( 'tag_subscribe(): the email parameter is empty.', 'convertkit' ),
-
-			'get_subscriber_by_email_email_empty'         => __( 'get_subscriber_by_email(): the email parameter is empty.', 'convertkit' ),
-			/* translators: Email Address */
-			'get_subscriber_by_email_none'                => __( 'No subscriber(s) exist in ConvertKit matching the email address %s.', 'convertkit' ),
-
-			'get_subscriber_by_id_subscriber_id_empty'    => __( 'get_subscriber_by_id(): the subscriber_id parameter is empty.', 'convertkit' ),
-
-			'get_subscriber_tags_subscriber_id_empty'     => __( 'get_subscriber_tags(): the subscriber_id parameter is empty.', 'convertkit' ),
-
-			'unsubscribe_email_empty'                     => __( 'unsubscribe(): the email parameter is empty.', 'convertkit' ),
-
-			'get_all_posts_posts_per_request_bound_too_low' => __( 'get_all_posts(): the posts_per_request parameter must be equal to or greater than 1.', 'convertkit' ),
-			'get_all_posts_posts_per_request_bound_too_high' => __( 'get_all_posts(): the posts_per_request parameter must be equal to or less than 50.', 'convertkit' ),
-
-			'get_posts_page_parameter_bound_too_low'      => __( 'get_posts(): the page parameter must be equal to or greater than 1.', 'convertkit' ),
-			'get_posts_per_page_parameter_bound_too_low'  => __( 'get_posts(): the per_page parameter must be equal to or greater than 1.', 'convertkit' ),
-			'get_posts_per_page_parameter_bound_too_high' => __( 'get_posts(): the per_page parameter must be equal to or less than 50.', 'convertkit' ),
-
-			/* translators: HTTP method */
-			'request_method_unsupported'                  => __( 'API request method %s is not supported in ConvertKit_API class.', 'convertkit' ),
-			'request_rate_limit_exceeded'                 => __( 'ConvertKit API Error: Rate limit hit.', 'convertkit' ),
-			'request_internal_server_error'               => __( 'ConvertKit API Error: Internal server error.', 'convertkit' ),
-			'request_bad_gateway'                         => __( 'ConvertKit API Error: Bad gateway.', 'convertkit' ),
-			'response_type_unexpected'                    => __( 'ConvertKit API Error: The response is not of the expected type array.', 'convertkit' ),
-		);
-
 	}
 
 }


### PR DESCRIPTION
## Summary

Updates WordPress Libraries to [1.3.9](https://github.com/ConvertKit/convertkit-wordpress-libraries/releases/tag/1.3.9)

Removes localized error messages, as the text domain (`convertkit`) for this Plugin matches the main ConvertKit Plugin - therefore, the localized error messages supplied by the WordPress Libraries don't need to have their text domain changed.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)