### PR TITLE
Add Notice Recommending Official Add-On

### DIFF
--- a/convertkit.php
+++ b/convertkit.php
@@ -40,6 +40,7 @@ if ( ! class_exists( 'ConvertKit_Review_Request' ) ) {
 // Load files that are always used.
 require_once CKGF_PLUGIN_PATH . '/includes/functions.php';
 require_once CKGF_PLUGIN_PATH . '/includes/class-ckgf-api.php';
+require_once CKGF_PLUGIN_PATH . '/includes/class-ckgf-notices.php';
 require_once CKGF_PLUGIN_PATH . '/includes/class-wp-ckgf.php';
 
 /**

--- a/includes/class-ckgf-notices.php
+++ b/includes/class-ckgf-notices.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Notices class.
+ *
+ * @package CKWC
+ * @author ConvertKit
+ */
+
+/**
+ * Notices class.
+ *
+ * @package CKWC
+ * @author ConvertKit
+ */
+class CKGF_Notices {
+
+	/**
+	 * Constructor.
+	 *
+	 * @since   1.4.2
+	 */
+	public function __construct() {
+
+		add_action( 'admin_init', array( $this, 'maybe_deactivate_plugin' ) );
+
+	}
+
+	/**
+	 * Deactivates this Plugin if the official Gravity Forms ConvertKit Add-On is active.
+	 *
+	 * @since   1.4.2
+	 */
+	public function maybe_deactivate_plugin() {
+
+		// If the official Gravity Forms ConvertKit Add-On is active, deactivate
+		// our Plugin.
+		if ( is_plugin_active( 'gravityformsconvertkit/convertkit.php' ) ) {
+			deactivate_plugins( 'convertkit-gravity-forms/convertkit.php' );
+			return;
+		}
+
+		// The official Gravity Forms ConvertKit Add-On is not installed.
+		// Recommend the user install it by showing a notice.
+		add_action( 'admin_notices', array( $this, 'output_notice' ) );
+
+	}
+
+	/**
+	 * Output a persistent notice in the WordPress Administration
+	 * telling users to migrate to the official Add-on.
+	 *
+	 * @since   1.4.2
+	 */
+	public function output_notice() {
+
+		?>
+		<div class="notice notice-warning">
+			<p>
+				<?php
+				printf(
+					'%s <a href="%s" target="_blank">%s</a>. %s',
+					esc_html__( 'ConvertKit Gravity Forms Add-On: Please install the official', 'convertkit' ),
+					esc_url( 'https://www.gravityforms.com/blog/convertkit-add-on/' ),
+					esc_html__( 'Gravity Forms ConvertKit Add-On', 'convertkit' ),
+					esc_html__( 'Your existing settings will automatically migrate once installed and active.', 'convertkit' )
+				);
+				?>
+			</p>
+		</div>
+		<?php
+
+	}
+
+}
+
+// Initialize class.
+add_action(
+	'convertkit_gravity_forms_initialize_admin',
+	function () {
+
+		new CKGF_Notices();
+
+	}
+);

--- a/readme.txt
+++ b/readme.txt
@@ -13,6 +13,8 @@ ConvertKit is an email marketing platform for capturing leads from your WordPres
 
 == Description ==
 
+** Please use the official [Gravity Forms ConvertKit Add-On](https://www.gravityforms.com/blog/convertkit-add-on/). Your existing settings will automatically migrate once installed and active. This Add-on will only receive security updates. **
+
 [ConvertKit](https://convertkit.com) makes it easy to capture more leads and sell more products by easily embedding email capture forms anywhere.
 
 This Plugin integrates Gravity Forms with ConvertKit, allowing form submissions to be automatically sent to your ConvertKit account.

--- a/tests/_support/Helper/Acceptance/GravityForms.php
+++ b/tests/_support/Helper/Acceptance/GravityForms.php
@@ -112,10 +112,6 @@ class GravityForms extends \Codeception\Module
 		// Wait for the Form Edit screen to load.
 		$I->waitForElementVisible('#no-fields');
 
-		// Open Advanced Fields Panel.
-		$I->click('button[aria-controls="add_advanced_fields"]');
-		$I->wait(2);
-
 		// Add Name Field.
 		$I->click('#add_advanced_fields button[data-type="name"]');
 		$I->wait(2);

--- a/tests/_support/Helper/Acceptance/ThirdPartyPlugin.php
+++ b/tests/_support/Helper/Acceptance/ThirdPartyPlugin.php
@@ -39,6 +39,10 @@ class ThirdPartyPlugin extends \Codeception\Module
 				$I->seePluginActivated('gravityforms');
 				break;
 
+			case 'gravity-forms-convertkit-add-on':
+				$I->seePluginActivated('gravityformsconvertkit');
+				break;
+
 			default:
 				$I->seePluginActivated($name);
 				break;
@@ -70,6 +74,10 @@ class ThirdPartyPlugin extends \Codeception\Module
 		switch ($name) {
 			case 'gravity-forms':
 				$I->deactivatePlugin('gravityforms');
+				break;
+
+			case 'gravity-forms-convertkit-add-on':
+				$I->deactivatePlugin('gravityformsconvertkit');
 				break;
 
 			default:

--- a/tests/acceptance/forms/FormCest.php
+++ b/tests/acceptance/forms/FormCest.php
@@ -62,7 +62,7 @@ class FormCest
 		// Complete Form Fields.
 		$I->fillField('.name_first input[type=text]', $firstName);
 		$I->fillField('.name_last input[type=text]', $lastName);
-		$I->fillField('.ginput_container_email input[type=text]', $emailAddress);
+		$I->fillField('.ginput_container_email input[type=email]', $emailAddress);
 
 		// Submit Form.
 		$I->click('Submit');
@@ -135,7 +135,7 @@ class FormCest
 		// Complete Form Fields.
 		$I->fillField('.name_first input[type=text]', $firstName);
 		$I->fillField('.name_last input[type=text]', $lastName);
-		$I->fillField('.ginput_container_email input[type=text]', $emailAddress);
+		$I->fillField('.ginput_container_email input[type=email]', $emailAddress);
 
 		// Submit Form.
 		$I->click('Submit');
@@ -320,7 +320,7 @@ class FormCest
 		// Complete Form Fields.
 		$I->fillField('.name_first input[type=text]', $firstName);
 		$I->fillField('.name_last input[type=text]', $lastName);
-		$I->fillField('.ginput_container_email input[type=text]', $emailAddress);
+		$I->fillField('.ginput_container_email input[type=email]', $emailAddress);
 		$I->selectOption('select.gfield_select', $_ENV['CONVERTKIT_API_ADDITIONAL_TAG_NAME']);
 
 		// Submit Form.
@@ -399,7 +399,7 @@ class FormCest
 		// Complete Form Fields.
 		$I->fillField('.name_first input[type=text]', $firstName);
 		$I->fillField('.name_last input[type=text]', $lastName);
-		$I->fillField('.ginput_container_email input[type=text]', $emailAddress);
+		$I->fillField('.ginput_container_email input[type=email]', $emailAddress);
 		$I->selectOption('select.gfield_select', $_ENV['CONVERTKIT_API_ADDITIONAL_TAG_NAME']);
 
 		// Submit Form.
@@ -478,7 +478,7 @@ class FormCest
 		// Complete Form Fields.
 		$I->fillField('.name_first input[type=text]', $firstName);
 		$I->fillField('.name_last input[type=text]', $lastName);
-		$I->fillField('.ginput_container_email input[type=text]', $emailAddress);
+		$I->fillField('.ginput_container_email input[type=email]', $emailAddress);
 		$I->selectOption( 'select.gfield_select', 'fakeTagNotInConvertKit' );
 
 		// Submit Form.
@@ -557,7 +557,7 @@ class FormCest
 		// Complete Form Fields.
 		$I->fillField('.name_first input[type=text]', $firstName);
 		$I->fillField('.name_last input[type=text]', $lastName);
-		$I->fillField('.ginput_container_email input[type=text]', $emailAddress);
+		$I->fillField('.ginput_container_email input[type=email]', $emailAddress);
 
 		// Submit Form.
 		$I->click('Submit');
@@ -641,7 +641,7 @@ class FormCest
 		// Complete Form Fields.
 		$I->fillField('.name_first input[type=text]', $firstName);
 		$I->fillField('.name_last input[type=text]', $lastName);
-		$I->fillField('.ginput_container_email input[type=text]', $emailAddress);
+		$I->fillField('.ginput_container_email input[type=email]', $emailAddress);
 
 		// Submit Form.
 		$I->click('Submit');
@@ -720,7 +720,7 @@ class FormCest
 		// Complete Form Fields.
 		$I->fillField('.name_first input[type=text]', $firstName);
 		$I->fillField('.name_last input[type=text]', $lastName);
-		$I->fillField('.ginput_container_email input[type=text]', $emailAddress);
+		$I->fillField('.ginput_container_email input[type=email]', $emailAddress);
 
 		// Submit Form.
 		$I->click('Submit');
@@ -790,7 +790,7 @@ class FormCest
 		// Complete Form Fields.
 		$I->fillField('.name_first input[type=text]', $firstName);
 		$I->fillField('.name_last input[type=text]', $lastName);
-		$I->fillField('.ginput_container_email input[type=text]', $emailAddress);
+		$I->fillField('.ginput_container_email input[type=email]', $emailAddress);
 
 		// Submit Form.
 		$I->click('Submit');

--- a/tests/acceptance/general/NoticesCest.php
+++ b/tests/acceptance/general/NoticesCest.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Tests the notices output recommending the official add-on.
+ *
+ * @since   1.4.2
+ */
+class NoticesCest
+{
+	/**
+	 * Holds the expected notice text.
+	 *
+	 * @since   1.4.2
+	 *
+	 * @var     string
+	 */
+	public $expectedNoticeText = 'ConvertKit Gravity Forms Add-On: Please install the official Gravity Forms ConvertKit Add-On. Your existing settings will automatically migrate once installed and active.';
+
+	/**
+	 * Run common actions before running the test functions in this class.
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function _before(AcceptanceTester $I)
+	{
+		$I->activateConvertKitPlugin($I);
+	}
+
+	/**
+	 * Test that the persistent notice displays with expected wording when the Plugin is active.
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testPersistentNoticeDisplays(AcceptanceTester $I)
+	{
+		// Confirm notice displays with expected text.
+		$I->seeElement('.notice-warning');
+		$I->see($this->expectedNoticeText);
+
+		// Confirm the link is valid.
+		$I->assertEquals(
+			$I->grabAttributeFrom('.notice-warning a', 'href'),
+			'https://www.gravityforms.com/blog/convertkit-add-on/'
+		);
+
+		// Deactivate Plugin.
+		$I->deactivateConvertKitPlugin($I);
+
+		// Confirm no notice from this Plugin displays.
+		$I->dontSee($this->expectedNoticeText);
+	}
+
+	/**
+	 * Test that the persistent notice does not display when the official add-on is active.
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testPersistentNoticeNotDisplayedWhenOfficialAddonActive(AcceptanceTester $I)
+	{
+		// Activate Gravity Forms and official add-on.
+		$I->activateThirdPartyPlugin($I, 'gravity-forms');
+		$I->activateThirdPartyPlugin($I, 'gravity-forms-convertkit-add-on');
+
+		// Confirm no notice from this Plugin displays.
+		$I->dontSee($this->expectedNoticeText);
+
+		// Confirm the official add-on displays its notice that it deactivated this Plugin.
+		$I->see('In order to prevent conflicts, we disabled the existing ConvertKit for Gravity Forms plugin.');
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 *
+	 * @since   1.2.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->resetConvertKitPlugin($I);
+	}
+}

--- a/tests/acceptance/general/NoticesCest.php
+++ b/tests/acceptance/general/NoticesCest.php
@@ -69,6 +69,7 @@ class NoticesCest
 		// Confirm no notice from this Plugin displays.
 		$I->dontSee($this->expectedNoticeText);
 
+		// When the official add-on is activated, it checks whether this Plugin is also active, deactivating it if so.
 		// Confirm the official add-on displays its notice that it deactivated this Plugin.
 		$I->see('In order to prevent conflicts, we disabled the existing ConvertKit for Gravity Forms plugin.');
 	}


### PR DESCRIPTION
## Summary

As requested [here](https://n7studios-workspace.slack.com/archives/C02KFR6N1GF/p1706737362342609?thread_ts=1706292948.745459&cid=C02KFR6N1GF):

- Adds a notice in the WordPress Administration screens recommending to install and activate the official Gravity Forms ConvertKit Add-On:

<img width="1060" alt="Screenshot 2024-02-08 at 14 34 59" src="https://github.com/ConvertKit/convertkit-gravity-forms/assets/1462305/6a0acfbf-0072-40b4-84d2-cab03872ad34">

- Updates the readme file to again recommend the official add-on.

Once the official add-on is installed and activated, it perform its own check to determine whether this Plugin is active, deactivating it if so.  They retain our settings.

## Testing

- `NoticesCest:testPersistentNoticeDisplays`: Test that the persistent notice displays when this Plugin is active.
- `NoticesCest:testPersistentNoticeNotDisplayedWhenOfficialAddonActive`: Test that the persistent notice does not display when the official add-on is activate.

## Checklist

* [x] I have [written a test](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)